### PR TITLE
WIP: AR-5 add hardcoded UV to item pages

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,9 +12,14 @@
  *
  *= require_tree .
  *= require_self
- 
+
  *
  * Used by blacklight_range_limit
  *= require  'blacklight_range_limit'
  *
 */
+.uv {
+  width:560px;
+  height:420px;
+  background-color: #000;
+}

--- a/app/views/catalog/_show_universal_viewer.html.erb
+++ b/app/views/catalog/_show_universal_viewer.html.erb
@@ -1,0 +1,19 @@
+<div
+  class="uv"
+  data-locale="en-GB:English (GB),cy-GB:Cymraeg"
+  data-config="/uv_config.json"
+  data-uri="https://pages.dlib.indiana.edu/concern/scanned_resources/dwh247324p/manifest" 
+  data-collectionindex="0"
+  data-manifestindex="0"
+  data-sequenceindex="0"
+  data-canvasindex="0"
+  data-xywh="-2204,-248,7873,4957"
+  data-rotation="0"
+  >
+</div>
+<script
+  type="text/javascript"
+  id="embedUV"
+  src="https://pages.dlib.indiana.edu/bower_includes/universalviewer/dist/uv-2.0.1/lib/embed.js">
+</script>
+<script type="text/javascript">/* wordpress fix */</script>

--- a/app/views/catalog/_show_upper_metadata_default.html.erb
+++ b/app/views/catalog/_show_upper_metadata_default.html.erb
@@ -1,0 +1,16 @@
+<%# copied from arclight to add Universal viewer %>
+<% if blacklight_config.show.component_metadata_partials.present? %>
+  <% parents = Arclight::Parents.from_solr_document(document).as_parents %>
+  <dl class="al-metadata-section breadcrumb-item breadcrumb-item-<%= parents.length + 3 %>">
+    <%= render 'show_universal_viewer'%>
+    <% blacklight_config.show.component_metadata_partials.each do |metadata| %>
+      <% doc_presenter = show_presenter(document).with_field_group(metadata) %>
+      <% generic_document_fields(metadata).each do |field_name, field| %>
+        <% if generic_should_render_field?(metadata, document, field) %>
+          <dt class="blacklight-<%= field_name.parameterize %>"><%= generic_render_document_field_label(metadata, document, field: field_name) %></dt>
+          <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field %></dd>
+        <% end %>
+      <% end %>
+    <% end %>
+  </dl>
+<% end %>


### PR DESCRIPTION
Quick and dirty UV, using the hardcoded data-uri. We'll probably need to bring in a senior who's worked with UV before to get it to actually hook up to the data. I'll put some more information from my findings in the ticket 

https://bugs.dlib.indiana.edu/browse/AR-5

![Image 2020-03-24 at 11 39 30 AM](https://user-images.githubusercontent.com/5492162/77464256-229db580-6dc4-11ea-81fd-2c86c269f1af.png)
