### PR TITLE
Sticky footer

### DIFF
--- a/app/assets/stylesheets/arclight.scss
+++ b/app/assets/stylesheets/arclight.scss
@@ -6,7 +6,7 @@ svg {
   width: 1rem;
 }
 body {
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
 }

--- a/app/assets/stylesheets/arclight.scss
+++ b/app/assets/stylesheets/arclight.scss
@@ -5,3 +5,11 @@ svg {
   height: 1rem;
   width: 1rem;
 }
+body {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+#main-container {
+  flex: 1 0 auto;
+}


### PR DESCRIPTION
# Summary 
Pads the body, so the footer is at the bottom of the page

# Related Issue
n/a

# Expected Behavior
If there isn't enough content to fill the page, the white space expands so that the footer is at the bottom of the page.

If there is more content than fits in the page, the footer is still below the viewport

# Screenshots / Video
Before: 

![Image 2020-03-31 at 11 23 55 AM](https://user-images.githubusercontent.com/5492162/78061592-44f27e80-7342-11ea-8e34-41550b3d1c4b.png)

After: 
![Screen Recording 2020-03-31 at 11 08 AM](https://user-images.githubusercontent.com/5492162/78061405-0c52a500-7342-11ea-94c3-bc07dfebbd09.gif)

# Deployment

This will probably need another assets precompile ran on the server after deployment
