### PR TITLE
Bug fix duplicate js loading

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,8 +22,6 @@
 //= require bootstrap
 //= require blacklight/blacklight
 
-//= require context_navigation
-
 //= require_tree .
 
 

--- a/app/assets/javascripts/arclight.js
+++ b/app/assets/javascripts/arclight.js
@@ -1,2 +1,12 @@
-//= require arclight/arclight
+//= require arclight/collection_scrollspy
+//= require arclight/collection_navigation
+
+// don't load context navigation file from arclight
+// require arclight/context_navigation
+
+//= require arclight/oembed_viewer
+//= require arclight/truncator
+
+// Vendor Scripts
+//= require responsiveTruncator
 //= require stickyfill


### PR DESCRIPTION

# Summary 
Bug fix for js error "Uncaught SyntaxError: Identifier 'NavigationDocument' has already been declared"

# Related Issue
https://bugs.dlib.indiana.edu/browse/AR-16

# Expected Behavior
Loading spinner should work without causing facets and dropdown menus to fail 

# Screenshots / Video
**Before:**
![image](https://user-images.githubusercontent.com/18175797/79338034-6c694f80-7edb-11ea-9b7f-794ba77bdc57.png)

**After:**
![image](https://user-images.githubusercontent.com/18175797/79338115-8d31a500-7edb-11ea-9577-2cd11fb6cd5c.png)


# Testing / Reproduction instructions
Make sure loading spinner is working on contents tab
Make sure facets can collapse and expand
Make sure drop down menus are functioning

# Deployment
Will deploy to staging when merged

