### PR TITLE
Bug fix: loading icon link

### DIFF
--- a/app/assets/javascripts/context_navigation.js.erb
+++ b/app/assets/javascripts/context_navigation.js.erb
@@ -100,7 +100,7 @@ class Placeholder {
   buildElement() {
     // CHANGED PLACEHOLDER ELEMENT
     const elementMarkup = '<div class="al-hierarchy-placeholder">' +
-      '<h3 class="col-md-9"> <img alt="loading icon" src="/assets/ajax-loader.gif"> Loading...</h3>' +
+      '<h3 class="col-md-9"> <img alt="loading icon" src="<%= image_path('ajax-loader.gif') %>"> Loading...</h3>' +
       '</div>';
     return $(elementMarkup);
   }


### PR DESCRIPTION
# Summary 
Bug fix to get the loading icon to show up

# Related Issue
https://bugs.dlib.indiana.edu/browse/AR-16
#30 

# Expected Behavior
The Loading icon gif should render

# Screenshots / Video
Old:
![Screen Recording 2020-04-15 at 08 37 AM](https://user-images.githubusercontent.com/5492162/79357091-67fd6080-7ef4-11ea-81bc-55f25a840ac6.gif)
New:
![Screen Recording 2020-04-15 at 08 38 AM](https://user-images.githubusercontent.com/5492162/79357153-7ba8c700-7ef4-11ea-87e6-3f25cf1b1acc.gif)

# Testing / Reproduction instructions

- [ ] Go to a collection that has a reasonable number of works
- [ ] Expand collection contents
- [ ] Try to observe the loading placeholder
