### PR TITLE
Ar 21 add devise back

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   include Blacklight::User
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
 
   # Method added by Blacklight; Blacklight uses #to_s on your

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,19 @@
 class User < ApplicationRecord
-
   # Connects this user object to Blacklights Bookmarks.
   include Blacklight::User
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
+
+  enum role: { manager: 0, admin: 1 }
+  after_initialize :set_default_role, if: :new_record?
+
+  def set_default_role
+    self.role ||= :manager
+  end
+
+  scope :admins, -> { where(role: :admin) }
 
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -34,7 +34,7 @@
         </a>
       </p>
       <p class="copyright">
-        <span class="line-break"><a href="https://accessibility.iu.edu/assistance" id="accessibility-link" title="Having trouble accessing this web page content? Please visit this page for assistance.">Accessibility</a> | <a href="https://libraries.indiana.edu/privacy" id="privacy-policy-link">Privacy Notice</a></span>
+        <span class="line-break"><%= render 'shared/user_auth_links' %> | <a href="https://accessibility.iu.edu/assistance" id="accessibility-link" title="Having trouble accessing this web page content? Please visit this page for assistance.">Accessibility</a> | <a href="https://libraries.indiana.edu/privacy" id="privacy-policy-link">Privacy Notice</a></span>
         <span class="hide-on-mobile"> | </span>
         <a href="https://www.iu.edu/copyright/index.html">Copyright</a> © 2020 <span class="line-break-small">The Trustees of <a href="https://www.iu.edu/" itemprop="url"><span itemprop="name">Indiana University</span></a></span>
       </p>

--- a/app/views/shared/_user_auth_links.html.erb
+++ b/app/views/shared/_user_auth_links.html.erb
@@ -1,0 +1,7 @@
+<% if has_user_authentication_provider? %>
+  <% if current_user %>
+    <%= link_to "Logout", destroy_user_session_path%>
+  <% else %>
+    <%= link_to "Admin", new_user_session_path%>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,8 +14,8 @@ Rails.application.routes.draw do
   end
 
   # DISABLE DEVISE ROUTES
-  # devise_for :users
-  
+  devise_for :users
+
   concern :exportable, Blacklight::Routes::Exportable.new
 
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do

--- a/db/migrate/20200414180833_add_role_to_users.rb
+++ b/db/migrate/20200414180833_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :role, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_10_151809) do
+ActiveRecord::Schema.define(version: 2020_04_14_180833) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -42,7 +42,20 @@ ActiveRecord::Schema.define(version: 2020_03_10_151809) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "guest", default: false
+    t.string "invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer "invitation_limit"
+    t.string "invited_by_type"
+    t.integer "invited_by_id"
+    t.integer "invitations_count", default: 0
+    t.integer "role"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
+    t.index ["invitations_count"], name: "index_users_on_invitations_count"
+    t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
+    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,20 +42,8 @@ ActiveRecord::Schema.define(version: 2020_04_14_180833) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "guest", default: false
-    t.string "invitation_token"
-    t.datetime "invitation_created_at"
-    t.datetime "invitation_sent_at"
-    t.datetime "invitation_accepted_at"
-    t.integer "invitation_limit"
-    t.string "invited_by_type"
-    t.integer "invited_by_id"
-    t.integer "invitations_count", default: 0
     t.integer "role"
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
-    t.index ["invitations_count"], name: "index_users_on_invitations_count"
-    t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
-    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,14 +5,9 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-User.where(email: 'jlhardes@iu.edu').first_or_create do |u|
-  u.password = 'testing123'
-end
-
-User.where(email: 'rdfloyd@iu.edu').first_or_create do |u|
-  u.password = 'testing123'
-end
-
-User.where(email: 'acrande@iu.edu').first_or_create do |u|
-  u.password = 'testing123'
+%w[jlhardes@iu.edu rdfloyd@iu.edu acrande@iu.edu].each do |email|
+  user = User.where(email: email).first_or_create do |u|
+    u.password = 'testing123'
+    u.role = 'admin'
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,14 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+User.where(email: 'jlhardes@iu.edu').first_or_create do |u|
+  u.password = 'testing123'
+end
+
+User.where(email: 'rdfloyd@iu.edu').first_or_create do |u|
+  u.password = 'testing123'
+end
+
+User.where(email: 'acrande@iu.edu').first_or_create do |u|
+  u.password = 'testing123'
+end


### PR DESCRIPTION
# Summary 
Adds Devise back, with the login in the footer. Also adds seeds for some admin users

# Related Issue
https://bugs.dlib.indiana.edu/browse/AR-21

# Expected Behavior
The users in the seeds should be able to log in.

# Screenshots / Video
![Screen Recording 2020-04-15 at 10 37 AM](https://user-images.githubusercontent.com/5492162/79369078-3e990080-7f05-11ea-8e2f-8c7b797f90e7.gif)

# Testing / Reproduction instructions

- [ ] Go to the home page
- [ ] click on the "admin" link in the footer
- [ ] Log in with 'jlhardes@iu.edu`/'testing123'
- [ ] click on the log out button in the footer

# Deployment

This will need a db:migrate and db:seed ran after deployment, if it's not already part of the pipeline

# Other Information
There is a follow on MR that is also part of this ticket to actually add the admin dashboard so that admins can manage users