### PR TITLE
Ar 18 add import all

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,3 +90,5 @@ gem 'devise-guests', '~> 0.6'
 gem 'blacklight-locale_picker'
 gem 'mysql2'
 gem 'whenever', require: false
+gem 'delayed_job_active_record'
+gem "delayed_job_web"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,16 @@ GEM
       thor
     crass (1.0.6)
     database_cleaner (1.8.3)
+    delayed_job (4.1.8)
+      activesupport (>= 3.0, < 6.1)
+    delayed_job_active_record (4.1.4)
+      activerecord (>= 3.0, < 6.1)
+      delayed_job (>= 3.0, < 5)
+    delayed_job_web (1.4.3)
+      activerecord (> 3.0.0)
+      delayed_job (> 2.0.3)
+      rack-protection (>= 1.5.5)
+      sinatra (>= 1.4.4)
     deprecation (1.0.0)
       activesupport
     devise (4.7.1)
@@ -198,6 +208,8 @@ GEM
     msgpack (1.3.3)
     multi_json (1.14.1)
     multipart-post (2.1.1)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     mysql2 (0.5.3)
     netrc (0.11.0)
     nio4r (2.5.2)
@@ -216,6 +228,8 @@ GEM
     public_suffix (4.0.3)
     puma (3.12.4)
     rack (2.2.2)
+    rack-protection (2.0.8.1)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.4.1)
@@ -297,6 +311,7 @@ GEM
     rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
+    ruby2_keywords (0.0.2)
     ruby_dep (1.5.0)
     rubyzip (2.2.0)
     sass (3.7.4)
@@ -327,6 +342,11 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
+    sinatra (2.0.8.1)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.8.1)
+      tilt (~> 2.0)
     slop (3.6.0)
     solr_wrapper (2.2.0)
       faraday
@@ -423,6 +443,8 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   coveralls
   database_cleaner
+  delayed_job_active_record
+  delayed_job_web
   devise
   devise-guests (~> 0.6)
   factory_bot

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -2,10 +2,17 @@ class AdminController < ApplicationController
   before_action :authenticate_user!
   
   def index
+    @users = User.all
+    @repositories = EadProcessor.get_repository_names
   end
 
   def index_eads
-    EadProcessor.import_eads
+    EadProcessor.delay.import_eads
+  end
+
+  def index_ead
+    repository = params[:format]
+    EadProcessor.delay.import_eads({ files: [repository] })
   end
 
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,11 @@
+class AdminController < ApplicationController
+  before_action :authenticate_user!
+  
+  def index
+  end
+
+  def index_eads
+    EadProcessor.import_eads
+  end
+
+end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,11 +1,30 @@
 <div class="container">
   
-  <h2>Manage Repositories</h2>
+  <h3>Manage Repositories</h3>
+  <%# if current_user.admin? %>
+    <div class="row col">
+      <%= link_to "Index All EADs", index_eads_url, remote: true, class: "btn btn-lg btn-primary mt-4 mb-4" %>
+    </div>
+  <%# end %>
   
-  <%= link_to "Import and Index All EADs", index_eads_url, remote: true, class: "btn btn-lg btn-primary" %>
+  <div class="row border-bottom mb-4">
+    <div class="col-md-9">
+      <h4>Repository</h4>
+    </div>
+    
+  </div>
+  <% @repositories.each do |repo| %>
+    <div class="row mb-4">
+      <div class="col-md-9">
+        <p><%= repo %></p>
+      </div>
+      <div class="col-md-3">
+        <%= link_to "Index Repository EADs", index_ead_url(repo), remote: true, class: 'btn btn-sm btn-primary' %>
+      </div>
+    </div>
+  <% end %>
 
-  <%# <h2>Manage Users</h2> %>
-  <div>
+  <div class="mt-4">
     <%= link_to t('blacklight.header_links.logout'), destroy_user_session_path %>
   </div>
 </div>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,0 +1,11 @@
+<div class="container">
+  
+  <h2>Manage Repositories</h2>
+  
+  <%= link_to "Import and Index All EADs", index_eads_url, remote: true, class: "btn btn-lg btn-primary" %>
+
+  <%# <h2>Manage Users</h2> %>
+  <div>
+    <%= link_to t('blacklight.header_links.logout'), destroy_user_session_path %>
+  </div>
+</div>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,11 +1,11 @@
 <div class="container">
   
   <h3>Manage Repositories</h3>
-  <%# if current_user.admin? %>
+  <% if current_user.admin? %>
     <div class="row col">
       <%= link_to "Index All EADs", index_eads_url, remote: true, class: "btn btn-lg btn-primary mt-4 mb-4" %>
     </div>
-  <%# end %>
+  <% end %>
   
   <div class="row border-bottom mb-4">
     <div class="col-md-9">

--- a/app/views/shared/_user_auth_links.html.erb
+++ b/app/views/shared/_user_auth_links.html.erb
@@ -2,6 +2,6 @@
   <% if current_user %>
     <%= link_to "Logout", destroy_user_session_path%>
   <% else %>
-    <%= link_to "Admin", new_user_session_path%>
+    <%= link_to "Admin", admin_path%>
   <% end %>
 <% end %>

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,8 @@ module Ngao
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    config.active_job.queue_adapter = :delayed_job
+    
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,9 @@ Rails.application.routes.draw do
   get '/admin', to: 'admin#index', as: 'admin'
 
   get 'admin/index_eads', to: 'admin#index_eads', as: 'index_eads'
+  get 'admin/index_ead', to: 'admin#index_ead', as: 'index_ead'
+
+  match "/delayed_job" => DelayedJobWeb, :anchor => false, :via => [:get, :post]
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,6 @@ Rails.application.routes.draw do
 
   end
 
-  # DISABLE DEVISE ROUTES
   devise_for :users
 
   concern :exportable, Blacklight::Routes::Exportable.new
@@ -29,5 +28,10 @@ Rails.application.routes.draw do
       delete 'clear'
     end
   end
+
+  get '/admin', to: 'admin#index', as: 'admin'
+
+  get 'admin/index_eads', to: 'admin#index_eads', as: 'index_eads'
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,9 @@ Rails.application.routes.draw do
   get 'admin/index_eads', to: 'admin#index_eads', as: 'index_eads'
   get 'admin/index_ead', to: 'admin#index_ead', as: 'index_ead'
 
-  match "/delayed_job" => DelayedJobWeb, :anchor => false, :via => [:get, :post]
+  authenticated :user do
+    mount DelayedJobWeb, at: "/delayed_job"
+  end
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20200420224554_create_delayed_jobs.rb
+++ b/db/migrate/20200420224554_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[5.2]
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_14_180833) do
+ActiveRecord::Schema.define(version: 2020_04_20_224554) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -22,6 +22,21 @@ ActiveRecord::Schema.define(version: 2020_04_14_180833) do
     t.datetime "updated_at", null: false
     t.index ["document_id"], name: "index_bookmarks_on_document_id"
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "searches", force: :cascade do |t|


### PR DESCRIPTION

# Summary 
Adds admin page where admins can import and index all Repositories or import and index one repository.

# Related Issue
AR-18 https://bugs.dlib.indiana.edu/browse/AR-18

# Expected Behavior

As a logged in admin user, you can view a page that allows you to import/index all repositories and allows you to select individual repositories for import/indexing

# Screenshots / Video
![image](https://user-images.githubusercontent.com/18175797/79889533-02f1b100-83b3-11ea-9480-6a9e5e188caa.png)

# Side Effects
Delayed jobs was added and deployment for delayed jobs was completed on a separate PR

# Testing / Reproduction instructions
1. Login as an admin
2. You will see a button to index all repository eads, as well as a list of individual repositories to index
3. Click button to index all
4. Click button next to repository to index individual repositories

1. Login as a manager
2. You should only see the list of repositories to import
3. Click button next to repository name to run index

You can view jobs in the delayed job queue at https://staging-ngao-web.notch8.cloud/delayed_job/overview

# Deployment

This will be deployed to Notch8 staging site after approved and merged.

# Other Information

This is the first PR for ticket AR-18. There is still further work to do for importing individual eads.