### PR TITLE
AR-29: Removed header and changed masthead

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,18 +1,7 @@
 <!--overriding from arclight 0.3.1 to remove devise and add IU header branding_bar, from https://assets.iu.edu/brand/3.2.x/header-iu.html -->
 <header>
   <%= render '/layouts/branding_bar' %>
-  <%# ADD IU BRANDING %>
-  <nav class="navbar navbar-expand-md navbar-dark bg-dark topbar" aria-label="utilities" role="navigation">
-    <div class="<%= container_classes %>">
-      <%= link_to application_name, root_path, class: "navbar-brand" %>
-      <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-
-      <%# REMOVED DEVISE LINKS %>
-
-    </div>
-  </nav>
+  <%# ADD IU BRANDING AND REMOVE BLACK NAVBAR %>
 
   <% if controller_name == 'catalog' && !has_search_parameters? && action_name == 'index' %>
     <div class='al-homepage-masthead jumbotron'>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -1,3 +1,6 @@
 en:
   arclight:
     masthead_heading: Archives Online at Indiana University
+    views:
+      home:
+        title: Archives Online at Indiana University

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -1,0 +1,3 @@
+en:
+  arclight:
+    masthead_heading: Archives Online at Indiana University

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,3 +1,3 @@
 en:
   blacklight:
-    application_name: 'Next Generation Archives Online'
+    application_name: 'Archives Online at Indiana University'


### PR DESCRIPTION
# Summary 
Removes the grey arclight header, renames the title

# Related Issue
https://bugs.dlib.indiana.edu/browse/AR-29

# Expected Behavior / Testing

- [ ] The black title bar should no longer show up
- [ ] The title in the tabbar and at the top of the page should say "Archives Online at Indiana University'

# Screenshots / Video
Now: 
![Image 2020-04-22 at 9 11 34 AM](https://user-images.githubusercontent.com/5492162/80006460-c1780900-8479-11ea-91eb-6ca95a241220.png)
Before:
![Image 2020-04-22 at 9 02 40 AM](https://user-images.githubusercontent.com/5492162/80006493-cb017100-8479-11ea-8255-6678f115393a.png)

