### PR TITLE
AR-28: moved devise links to menu bar

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -34,7 +34,7 @@
         </a>
       </p>
       <p class="copyright">
-        <span class="line-break"><%= render 'shared/user_auth_links' %> | <a href="https://accessibility.iu.edu/assistance" id="accessibility-link" title="Having trouble accessing this web page content? Please visit this page for assistance.">Accessibility</a> | <a href="https://libraries.indiana.edu/privacy" id="privacy-policy-link">Privacy Notice</a></span>
+        <span class="line-break"><a href="https://accessibility.iu.edu/assistance" id="accessibility-link" title="Having trouble accessing this web page content? Please visit this page for assistance.">Accessibility</a> | <a href="https://libraries.indiana.edu/privacy" id="privacy-policy-link">Privacy Notice</a></span>
         <span class="hide-on-mobile"> | </span>
         <a href="https://www.iu.edu/copyright/index.html">Copyright</a> © 2020 <span class="line-break-small">The Trustees of <a href="https://www.iu.edu/" itemprop="url"><span itemprop="name">Indiana University</span></a></span>
       </p>

--- a/app/views/shared/_main_menu_links.html.erb
+++ b/app/views/shared/_main_menu_links.html.erb
@@ -1,0 +1,8 @@
+<%# IMPORTED FROM ARCLIGHT to add user auth links %>
+<li class="nav-item <%= repositories_active_class %>">
+  <%= link_to t('arclight.routes.repositories'), arclight_engine.repositories_path, class: 'nav-link' %>
+</li>
+<li class="nav-item ml-3 <%= collection_active_class %>">
+  <%= link_to t('arclight.routes.collections'), arclight_engine.collections_path, class: 'nav-link' %>
+</li>
+<%= render 'shared/user_auth_links' %>

--- a/app/views/shared/_user_auth_links.html.erb
+++ b/app/views/shared/_user_auth_links.html.erb
@@ -1,7 +1,14 @@
 <% if has_user_authentication_provider? %>
   <% if current_user %>
-    <%= link_to "Logout", destroy_user_session_path%>
+    <li class="nav-item ml-3">
+      <%= link_to "Admin", admin_path, class: 'nav-link' %>
+    </li>
+    <li class="nav-item ml-3">
+      <%= link_to "Logout", destroy_user_session_path, class: 'nav-link' %>
+    </li>
   <% else %>
-    <%= link_to "Admin", admin_path%>
+    <li class="nav-item ml-3">
+      <%= link_to "Log In", new_user_session_path, class: 'nav-link' %>
+    </li>
   <% end %>
 <% end %>

--- a/app/views/shared/_user_auth_links.html.erb
+++ b/app/views/shared/_user_auth_links.html.erb
@@ -8,7 +8,7 @@
     </li>
   <% else %>
     <li class="nav-item ml-3">
-      <%= link_to "Log In", new_user_session_path, class: 'nav-link' %>
+      <%= link_to "Admin", admin_path, class: 'nav-link' %>
     </li>
   <% end %>
 <% end %>


### PR DESCRIPTION
# Summary 
Moves the login from the footer to be next to repositories and collections

# Related Issue
https://bugs.dlib.indiana.edu/browse/AR-29

# Expected Behavior

- [ ] The login link should not be in the footer.
- [ ] If logged out, there should be a 3 elements in the menu bar: Respoitories, Collections, and Admin
- [ ] Clicking on Admin should ask you to log in, and then direct you to the admin dashboard
- [ ] After logging in, there should also be an element to log out.

# Screenshots / Video
Before:
![Image 2020-04-22 at 9 17 35 AM](https://user-images.githubusercontent.com/5492162/80007115-b07bc780-847a-11ea-83df-aa57dfe38ce8.png)

After:
![Screen Recording 2020-04-22 at 09 22 AM](https://user-images.githubusercontent.com/5492162/80007243-d86b2b00-847a-11ea-9264-679770166c73.gif)
