### PR TITLE
Ar 18: add bootstrap styling to devise page views

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'jquery-rails'
 gem 'devise'
 gem 'devise-guests', '~> 0.6'
+gem 'devise-bootstrap-views', '~> 1.0'
 gem 'blacklight-locale_picker'
 gem 'mysql2'
 gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,8 +125,10 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-bootstrap-views (1.1.0)
     devise-guests (0.7.0)
       devise
+    devise-i18n (1.1.2)
     diff-lcs (1.3)
     docile (1.3.2)
     domain_name (0.5.20190701)
@@ -446,7 +448,9 @@ DEPENDENCIES
   delayed_job_active_record
   delayed_job_web
   devise
+  devise-bootstrap-views (~> 1.0)
   devise-guests (~> 0.6)
+  devise-i18n
   factory_bot
   jbuilder (~> 2.5)
   jquery-rails

--- a/README.md
+++ b/README.md
@@ -81,3 +81,11 @@ bundle update arclight
 ## Updating the application
 
 See https://github.com/sul-dlss/arclight/wiki/Upgrading-your-ArcLight-application
+
+## Customizing the devise views
+
+This uses the [Devise Bootstrap Views](https://github.com/hisea/devise-bootstrap-views) gem to style the user authentication pages.
+
+The gem supports i18n localizations, though it is not enabled by default. To add it to the app, use [devise-i18n](https://github.com/tigrish/devise-i18n)
+
+This app uses the default views in the bootstrap-views gem, if you wish to customize them further, run `rails generate devise:views:bootstrap_templates` to create a local copy to modify.


### PR DESCRIPTION
# Summary 
Adds bootstrap for the devise pages

# Related Issue
https://bugs.dlib.indiana.edu/browse/AR-18

# Expected Behavior
The devise pages should have styling consistent with the rest of the site

# Screenshots / Video
Before:
![Image 2020-04-22 at 9 40 17 AM](https://user-images.githubusercontent.com/5492162/80009008-53cddc00-847d-11ea-90fa-1faa7a044f56.png)
![Image 2020-04-22 at 9 40 24 AM](https://user-images.githubusercontent.com/5492162/80009022-56c8cc80-847d-11ea-9472-bd911e27480b.png)

After: 
![Image 2020-04-22 at 9 44 01 AM](https://user-images.githubusercontent.com/5492162/80009446-ee2e1f80-847d-11ea-8652-8f19c6f544c6.png)
![Image 2020-04-22 at 9 44 10 AM](https://user-images.githubusercontent.com/5492162/80009458-f2f2d380-847d-11ea-86f6-e18e2529d597.png)

# Side Effects

I added a gem to add these views, which also have some helper methods to support it. It also includes support for i18ns, but I didn't use it

# Testing / Reproduction instructions
Go to The login screen and recover password screen and see if the form looks different.