### PR TITLE
redirect to admin dashboard after signing in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,4 +7,12 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     stored_location_for(resource) || admin_path
   end
+
+  def after_accept_path_for(resource)
+    stored_location_for(resource) || admin_path
+  end
+
+  def after_invite_path_for(resource)
+    stored_location_for(resource) || admin_path
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,7 @@ class ApplicationController < ActionController::Base
   include Blacklight::LocalePicker::Concern
   layout :determine_layout if respond_to? :layout
 
+  def after_sign_in_path_for(resource)
+    stored_location_for(resource) || admin_path
+  end
 end

--- a/app/views/shared/_user_auth_links.html.erb
+++ b/app/views/shared/_user_auth_links.html.erb
@@ -1,14 +1,12 @@
-<% if has_user_authentication_provider? %>
-  <% if current_user %>
-    <li class="nav-item ml-3">
-      <%= link_to "Admin", admin_path, class: 'nav-link' %>
-    </li>
-    <li class="nav-item ml-3">
-      <%= link_to "Logout", destroy_user_session_path, class: 'nav-link' %>
-    </li>
-  <% else %>
-    <li class="nav-item ml-3">
-      <%= link_to "Admin", admin_path, class: 'nav-link' %>
-    </li>
-  <% end %>
+<% if current_user %>
+  <li class="nav-item ml-3">
+    <%= link_to "Admin", admin_path, class: 'nav-link' %>
+  </li>
+  <li class="nav-item ml-3">
+    <%= link_to "Logout", destroy_user_session_path, class: 'nav-link' %>
+  </li>
+<% else %>
+  <li class="nav-item ml-3">
+    <%= link_to "Admin", admin_path, class: 'nav-link' %>
+  </li>
 <% end %>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,7 @@ Capybara.enable_aria_label = true
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
+  config.include Devise::TestHelpers, type: :view
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/views/shared/_header_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_header_navbar.html.erb_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe 'shared/_header_navbar.html.erb', type: :view do
   context 'header' do
     before do


### PR DESCRIPTION
# Summary 
Redirects the user to the admin dashboard after signing in, no matter where they logged in from

# Expected Behavior
After logging in, the user should be redirected to the admin dashboard, no matter where they logged in from.

After accepting an invitation, the user should also be redirected to the admin page

# Screenshots / Video
After sign in: 
![Screen Recording 2020-04-28 at 08 44 AM](https://user-images.githubusercontent.com/5492162/80509747-a8b29c00-892e-11ea-98cf-2b387732980b.gif)


After invite:
![Screen Recording 2020-04-28 at 08 52 AM](https://user-images.githubusercontent.com/5492162/80509714-9e909d80-892e-11ea-94cd-8bb420bb4af9.gif)


# Side Effects

This will change the log in behavior, make sure this behavior is desired

# Testing / Reproduction instructions

Log in as an admin using the normal login page (<hostname>/users/sign_in)
make sure you're redirected to the admin dashboard
invite a new user
make sure you're redirected to the admin dashboard
log out and accept the invite
make sure you're redirected to the admin dashboard
