### PR TITLE
Updated US-InU in campus helper

### DIFF
--- a/app/helpers/campus_helper.rb
+++ b/app/helpers/campus_helper.rb
@@ -3,7 +3,7 @@ module CampusHelper
   include ActiveSupport::Concern
 
   CAMPUSES = {
-    "US-InU" => "Indiana University, Bloomington",
+    "US-InU" => "Indiana University Bloomington",
     "US-InU-Sb" => "Indiana University South Bend",
     "US-InU-Se" => "Indiana University Southeast",
     "US-inrmiue" => "Indiana University East",


### PR DESCRIPTION
# Summary 
Quick text fix to update the repository name for Indiana University Bloomington (no comma)

# Related Issue
https://bugs.dlib.indiana.edu/browse/AR-33

# Screenshots / Video
Before (comma):
![Image 2020-04-28 at 10 20 35 AM](https://user-images.githubusercontent.com/5492162/80517688-4b244c80-893a-11ea-97a9-fb4abc249a10.png)

After (no comma):
![Image 2020-04-28 at 10 19 56 AM](https://user-images.githubusercontent.com/5492162/80517717-54adb480-893a-11ea-81c6-7fd999f9478f.png)


