### PR TITLE
adds default campus value

### DIFF
--- a/app/helpers/campus_helper.rb
+++ b/app/helpers/campus_helper.rb
@@ -13,7 +13,7 @@ module CampusHelper
   }
 
   def convert_campus_id value
-    return CAMPUSES[value]
+    # returns a default value of "Indiana University" if there is no corresponding mainagencycode
+    CAMPUSES[value] || "Indiana University"
   end
-  
 end


### PR DESCRIPTION
# Summary 
Makes the default campus "Indiana University"

# Related Issue
https://bugs.dlib.indiana.edu/browse/AR-34

# Expected Behavior
If the mainagencycode is not recognized, it should default the campus to "Indiana University". 

# Screenshots / Video
I edited one of the EADs before importing it, to change the mainagencycode into something I knew wouldn't be recognized. The campus was stored as Indiana University 
![Image 2020-04-28 at 11 17 36 AM](https://user-images.githubusercontent.com/5492162/80535769-2fc73a80-8956-11ea-828c-11898938c145.png)


# Dependencies
#49 isn't a true dependency, but I'm opening the PR on top of it to minimize merge conflicts

# Testing / Reproduction instructions
Edit the mainagencycode on an EAD
import it
Verify that the imported collection has the campus set as Indiana University
Go to the search results page, and check the campuses facet

# Other Information
While you can catch these "wrong" imports using the Campus facet in the search results, it may be a good idea to have a catchall section in the repositories list? 