### PR TITLE
force page to reload when switching context

### DIFF
--- a/app/views/viewers/_universal_viewer.html.erb
+++ b/app/views/viewers/_universal_viewer.html.erb
@@ -1,4 +1,5 @@
-<div 
+<div
+  id="uv"
   class="uv" 
   data-locale="en-GB:English (GB),cy-GB:Cymraeg" 
   data-config="/uv_config.json" 
@@ -15,4 +16,17 @@
   type="text/javascript" 
   id="embedUV" 
   src="https://pages.dlib.indiana.edu/bower_includes/universalviewer/dist/uv-2.0.1/lib/embed.js">
+</script>
+
+<script>
+  (function() {
+    var firstLoad = true;
+    Blacklight.onLoad(function () {
+      if (!firstLoad) {
+        window.location.reload();
+      } else {
+        firstLoad = false;
+      }
+    })
+  })();
 </script>


### PR DESCRIPTION

# Summary 
UV does not reload new items when context is switched. 

# Related Issue
https://bugs.dlib.indiana.edu/browse/AR-24

# Expected Behavior

When switching context, the UV should load the new document content

# Screenshots / Video
https://share.getcloudapp.com/kpuL75dr

# Side Effects

This forces a page reload so the javascript that fetches the external viewer will run. 

# Testing / Reproduction instructions

1. Load a document with online content
2. Select a second document with online content
3. UV should load content from new item

# Deployment

Will deploy to staging
