### PR TITLE
Ar 31 update colors

### DIFF
--- a/app/assets/stylesheets/iu-branding.scss
+++ b/app/assets/stylesheets/iu-branding.scss
@@ -4,8 +4,14 @@
 a {
   color: $iu-crimson;
 }
+a:hover {
+  color: $iu-mahogany;
+}
 .page-link {
   color: $iu-crimson;
+}
+.page-link:hover {
+  color: $iu-mahogany;
 }
 .page-item.active .page-link {
   background-color: $iu-crimson;
@@ -16,12 +22,21 @@ a {
   background-color: $iu-crimson;
   border-color: $iu-mahogany;
 }
+.btn-primary:hover, .btn-primary:active {
+  background-color: $iu-mahogany;
+}
 .btn-secondary{
   background-color: $iu-mahogany;
 }
 .btn-outline-secondary {
   border-color: $iu-mahogany;
 }
+
+// The "X" button to remove a facet from your search results
+.btn-danger:hover, .applied-filter .remove:hover  {
+  background-color: $iu-cream;
+}
+
 // active colors for toggable buttons on search results
 .btn-outline-secondary:not(:disabled):not(.disabled):active, .btn-outline-secondary:not(:disabled):not(.disabled).active,
 .show > .btn-outline-secondary.dropdown-toggle {
@@ -34,6 +49,10 @@ a {
 // search button
 .search-btn {
   background-color: $iu-crimson;
+}
+.btn-primary:not(:disabled):not(.disabled):active, .btn-primary:not(:disabled):not(.disabled).active,
+.show > .btn-primary.dropdown-toggle, .btn-primary:focus, .btn-primary.focus {
+  background-color: $iu-mahogany;
 }
 // facet colors
 .card {
@@ -91,4 +110,15 @@ li.al-collection-context .al-online-content-icon svg,
 // tabs on the collect/item pages
 .nav.nav-tabs .nav-item .nav-link:not(.active) {
   background-color: $iu-cream;
+}
+
+// sliders on date range facet
+.slider-handle {
+  background-image: linear-gradient($iu-crimson 0%, $iu-crimson 100%) !important;
+}
+
+// change search button dropshadow to iu crimson
+.btn-primary:focus, .btn-primary.focus, .btn-primary:not(:disabled):not(.disabled):active:focus,
+.btn-primary:not(:disabled):not(.disabled).active:focus, .show > .btn-primary.dropdown-toggle:focus {
+  box-shadow: 0 0 0 0.2rem rgba(153, 0, 0, 0.5);
 }

--- a/app/assets/stylesheets/iu-branding.scss
+++ b/app/assets/stylesheets/iu-branding.scss
@@ -1,0 +1,94 @@
+@import "iu_variables";
+
+// links (e.g. in the menu bar)
+a {
+  color: $iu-crimson;
+}
+.page-link {
+  color: $iu-crimson;
+}
+.page-item.active .page-link {
+  background-color: $iu-crimson;
+}
+
+// button colors
+.btn-primary {
+  background-color: $iu-crimson;
+  border-color: $iu-mahogany;
+}
+.btn-secondary{
+  background-color: $iu-mahogany;
+}
+.btn-outline-secondary {
+  border-color: $iu-mahogany;
+}
+// active colors for toggable buttons on search results
+.btn-outline-secondary:not(:disabled):not(.disabled):active, .btn-outline-secondary:not(:disabled):not(.disabled).active,
+.show > .btn-outline-secondary.dropdown-toggle {
+  background-color: $iu-mahogany;
+}
+// search box outlines
+.custom-select, #q {
+  border-color: $iu-mahogany;
+}
+// search button
+.search-btn {
+  background-color: $iu-crimson;
+}
+// facet colors
+.card {
+  background-color: $iu-cream;
+
+}
+// Active (i.g. elected) facet
+.bg-sucess, .facet-limit-active {
+  border-color: $iu-crimson !important;
+  .card-header {
+    background-color: $iu-crimson !important;
+    .btn{
+      color: $iu-cream;
+    }
+  }
+  .card-body > .facet-values  {
+    color: $iu-crimson;
+  }
+}
+.text-success, .facet-values li .selected {
+  color: $iu-crimson !important;
+}
+
+// icon colors
+article.document .blacklight-icons svg {
+  fill: $iu-mahogany;
+}
+
+// online content icon
+article.document .blacklight-icons.al-online-content-icon svg,
+li.al-collection-context .al-online-content-icon svg,
+.al-online-content-icon .blacklight-icons svg {
+  fill: $iu-crimson;
+}
+
+// extents (eg "# items")
+.documents-list article.document .document-title-heading .al-document-extent,
+.documents-online_contents article.document .document-title-heading .al-document-extent {
+  background-color: $iu-cream;
+}
+// Raw item count (eg. "#") in the collection/item tabs
+.badge-secondary {
+  background-color: $iu-mahogany;
+}
+
+// Search "label" on the menubar
+.input-group-text {
+  background-color: $iu-cream;
+}
+
+// item show page action box (e.g. downloads)
+.al-show-actions-box {
+  background-color: $iu-cream;
+}
+// tabs on the collect/item pages
+.nav.nav-tabs .nav-item .nav-link:not(.active) {
+  background-color: $iu-cream;
+}

--- a/app/views/viewers/_universal_viewer.html.erb
+++ b/app/views/viewers/_universal_viewer.html.erb
@@ -1,4 +1,5 @@
-<div 
+<div
+  id="uv"
   class="uv" 
   data-locale="en-GB:English (GB),cy-GB:Cymraeg" 
   data-config="/uv_config.json" 
@@ -15,4 +16,17 @@
   type="text/javascript" 
   id="embedUV" 
   src="https://pages.dlib.indiana.edu/bower_includes/universalviewer/dist/uv-2.0.1/lib/embed.js">
+</script>
+
+<script>
+  (function() {
+    var firstLoad = true;
+    Blacklight.onLoad(function () {
+      if (!firstLoad) {
+        window.location.reload();
+      } else {
+        firstLoad = false;
+      }
+    })
+  })();
 </script>


### PR DESCRIPTION
# Summary 
CSS overrides to override Arclight colors to match IU branding

# Related Issue
https://bugs.dlib.indiana.edu/browse/AR-31
# Expected Behavior
It'll use the 3 colors specified in the ticket for most branding, instead of the arclight colors
# Screenshots / Video
![Screen Recording 2020-04-29 at 05 06 PM](https://user-images.githubusercontent.com/5492162/80658838-1b5d6d80-8a3c-11ea-8421-25ccfc423b59.gif)

# Dependencies
This is built on top of the scss variable work for #53, and should be merged into it

# Side Effects

I know there are some questionable css practices here: we actually **do** want to override the color for all links, unless otherwise specified. 

Also, there are a couple !important calls here, which are needed to override elements that were declared as important inside arclight