### PR TITLE
Ar35 fix campus bug

### DIFF
--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -21,6 +21,7 @@ module ArclightHelper
   def parents_to_links(document)
     breadcrumb_links = []
     breadcrumb_links << add_campus_link(document) unless document.campus.nil?
+    breadcrumb_links << add_parent_campus_link(document) unless document.parent_campus.nil? && !document.campus.nil?
     breadcrumb_links << build_repository_link(document)
     breadcrumb_links << document_parents(document).map do |parent|
       link_to parent.label, solr_document_path(parent.global_id)
@@ -39,6 +40,7 @@ module ArclightHelper
   def regular_compact_breadcrumbs(document)
     breadcrumb_links = []
     breadcrumb_links << add_campus_link(document) unless document.campus.nil?
+    breadcrumb_links << add_parent_campus_link(document) unless document.parent_campus.nil? && !document.campus.nil?
     breadcrumb_links << build_repository_link(document)
 
     parents = document_parents(document)
@@ -279,7 +281,7 @@ module ArclightHelper
 
   def within_original_tree?(document)
     Array.wrap(params['original_parents']).map do |parent|
-      Arclight::Parent.new(id: parent, eadid: document.parent_ids.first, level: nil, label: nil).global_id
+      Arclight::Parent.new(id: parent, eadid: document.parent_ids.first, campus: document.parent_campus, level: nil, label: nil).global_id
     end.include?(document.id)
   end
 
@@ -339,6 +341,12 @@ module ArclightHelper
     def add_campus_link(document)
       campus_name = content_tag(:span, convert_campus_id(document.campus))
       search_query = "/?f[campus_unit_sim][]=#{document.campus}&q=&search_field=all_fields"
+      link_to(campus_name, search_query)
+    end
+
+    def add_parent_campus_link(document)
+      campus_name = content_tag(:span, convert_campus_id(document.parent_campus&.first))
+      search_query = "/?f[parent_campus_unit_sim][]=#{document.parent_campus}&q=&search_field=all_fields"
       link_to(campus_name, search_query)
     end
 end

--- a/app/helpers/campus_helper.rb
+++ b/app/helpers/campus_helper.rb
@@ -1,19 +1,19 @@
+# frozen_string_literal: true
 
 module CampusHelper
   include ActiveSupport::Concern
 
   CAMPUSES = {
-    "US-InU" => "Indiana University Bloomington",
-    "US-InU-Sb" => "Indiana University South Bend",
-    "US-InU-Se" => "Indiana University Southeast",
-    "US-inrmiue" => "Indiana University East",
-    "US-InU-K" => "Indiana University Kokomo",
-    "US-iniu" => "Indiana University-Purdue University, Indianapolis",
-    "US-InU-N" => "Indiana University Northwest"
+    'US-InU' => 'Indiana University Bloomington',
+    'US-InU-Sb' => 'Indiana University South Bend',
+    'US-InU-Se' => 'Indiana University Southeast',
+    'US-inrmiue' => 'Indiana University East',
+    'US-InU-K' => 'Indiana University Kokomo',
+    'US-iniu' => 'Indiana University-Purdue University, Indianapolis',
+    'US-InU-N' => 'Indiana University Northwest'
   }
 
-  def convert_campus_id value
-    return CAMPUSES[value]
+  def convert_campus_id(value)
+    CAMPUSES[value] || 'Indiana University'
   end
-  
 end

--- a/app/models/arclight/parent.rb
+++ b/app/models/arclight/parent.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Arclight
+  ##
+  # Logic containing information about Solr_Ead "Parent"
+  # https://github.com/awead/solr_ead/blob/8cf7ffaa66e0e4c9c0b12f5646d6c2e20984cd99/lib/solr_ead/behaviors.rb#L54-L57
+  class Parent
+    attr_reader :id, :label, :eadid, :campus, :level
+    def initialize(id:, label:, eadid:, campus:, level:)
+      @id = id
+      @label = label
+      @eadid = eadid
+      @campus = campus
+      @level = level
+    end
+
+    ##
+    # Concatenates the eadid and the id, to return an "id" in the context of
+    # Blacklight and Solr
+    # @return [String]
+    def global_id
+      return id if eadid == id
+
+      "#{eadid}#{id}"
+    end
+  end
+end

--- a/app/models/arclight/parents.rb
+++ b/app/models/arclight/parents.rb
@@ -10,7 +10,7 @@ module Arclight
       @ids = ids
       @labels = labels
       @eadid = eadid
-      @campus = @campus
+      @campus = campus
       @levels = levels
     end
 

--- a/app/models/arclight/parents.rb
+++ b/app/models/arclight/parents.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Arclight
+  ##
+  # Object for parsing and formalizing Solr_Ead "Parents"
+  # https://github.com/awead/solr_ead/blob/8cf7ffaa66e0e4c9c0b12f5646d6c2e20984cd99/lib/solr_ead/behaviors.rb#L54-L57
+  class Parents
+    attr_reader :ids, :labels, :campus, :levels
+    def initialize(ids:, labels:, eadid:, campus:, levels:)
+      @ids = ids
+      @labels = labels
+      @eadid = eadid
+      @campus = @campus
+      @levels = levels
+    end
+
+    def eadid
+      Arclight::NormalizedId.new(@eadid).to_s
+    end
+
+    ##
+    # @return [Array[Arclight::Parent]]
+    def as_parents
+      ids.map.with_index { |_id, idx| Arclight::Parent.new(id: ids[idx], label: labels[idx], eadid: eadid, campus: campus, level: levels[idx]) }
+    end
+
+    ##
+    # @param [SolrDocument] document
+    def self.from_solr_document(document)
+      ids = document.parent_ids
+      labels = document.parent_labels
+      eadid = document.eadid
+      campus = document.campus
+      levels = document.parent_levels
+      new(ids: ids, labels: labels, eadid: eadid, campus: campus, levels: levels)
+    end
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class SolrDocument
   include Blacklight::Solr::Document
- include Arclight::SolrDocument
+  include Arclight::SolrDocument
 
   # self.unique_key = 'id'
 
@@ -20,5 +20,9 @@ class SolrDocument
 
   def campus
     first('campus_unit_ssm')
+  end
+
+  def parent_campus
+    fetch('parent_campus_unit_ssm', [])
   end
 end

--- a/app/views/shared/_show_breadcrumbs.html.erb
+++ b/app/views/shared/_show_breadcrumbs.html.erb
@@ -9,7 +9,11 @@
       <% if document.campus.present? %>
         <span class="media-body" aria-hidden="true"><%= blacklight_icon :campus, classes: 'al-campus-content-icon' %></span>
         <span class="col"><%= add_campus_link(document) %></span>
+      <% elsif document.parent_campus.present? %>
+        <span class="media-body" aria-hidden="true"><%= blacklight_icon :campus, classes: 'al-campus-content-icon' %></span>
+        <span class="col"><%= add_parent_campus_link(document) %></span>
       <% else %>
+        <span class="media-body" aria-hidden="true"><%= blacklight_icon :campus, classes: 'al-campus-content-icon' %></span>
         <span class="col">Indiana University</span>
       <% end %>
     </li>

--- a/app/views/shared/_show_breadcrumbs.html.erb
+++ b/app/views/shared/_show_breadcrumbs.html.erb
@@ -10,7 +10,7 @@
         <span class="media-body" aria-hidden="true"><%= blacklight_icon :campus, classes: 'al-campus-content-icon' %></span>
         <span class="col"><%= add_campus_link(document) %></span>
       <% else %>
-        <span class="col">Campus</span>
+        <span class="col">Indiana University</span>
       <% end %>
     </li>
     <li class="media breadcrumb-item breadcrumb-item-2">

--- a/lib/ngao-arclight/traject/ead2_config.rb
+++ b/lib/ngao-arclight/traject/ead2_config.rb
@@ -366,6 +366,17 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
     end
   end
 
+  to_field 'parent_campus_unit_ssm' do |_record, accumulator, context|
+    ## Top level document
+    accumulator.concat context.clipboard[:parent].output_hash['campus_unit_ssm']
+    ## Other components
+    context.output_hash['parent_ssim']&.drop(1)&.each do |id|
+      accumulator.concat Array
+        .wrap(context.clipboard[:parent].output_hash['components'])
+        .select { |c| c['ref_ssi'] == [id] }.map { |c| c['campus_unit_ssm'] }.flatten
+    end
+  end
+
   to_field 'unitid_ssm', extract_xpath('./did/unitid')
   to_field 'collection_unitid_ssm' do |_record, accumulator, context|
     accumulator.concat Array.wrap(context.clipboard[:parent].output_hash['unitid_ssm'])


### PR DESCRIPTION

# Summary 
Campus is missing from breadcrumbs when you drill down into child components

# Related Issue
https://bugs.dlib.indiana.edu/browse/AR-35

# Expected Behavior

The campus should appear on all of the breadcrumbs

# Screenshots / Video

<img width="721" alt="Screen Shot 2020-05-01 at 11 46 17 AM" src="https://user-images.githubusercontent.com/18175797/80832387-6c3aa680-8ba1-11ea-9352-27b0dbdbd825.png">

# Dependencies

This requires reindexing
 
