### PR TITLE
Fixed collection > online content placeholder

### DIFF
--- a/app/assets/javascripts/collection_navigation.js.erb
+++ b/app/assets/javascripts/collection_navigation.js.erb
@@ -1,0 +1,98 @@
+// Imported from arclight to override placeholder
+(function (global) {
+  var CollectionNavigation;
+
+  CollectionNavigation = {
+    init: function (el, page = 1) {
+      var $el = $(el);
+      var data = $el.data();
+      // Add a placeholder so flashes of text are not as significant
+      // replaced placeholder from arclight
+      var placeholder = '<div class="al-hierarchy-placeholder">' +
+        '<h3 class="col-md-9"> <img alt="loading icon" src="<%= image_path('ajax-loader.gif') %>"> Loading...</h3>' +
+        '</div>';
+      $el.html(placeholder);
+      $.ajax({
+        url: data.arclight.path,
+        data: {
+          'f[component_level_isim][]': data.arclight.level,
+          'f[has_online_content_ssim][]': data.arclight.access,
+          'f[collection_sim][]': data.arclight.name,
+          'f[parent_ssim][]': data.arclight.parent,
+          page: page,
+          search_field: data.arclight.search_field,
+          view: data.arclight.view || 'hierarchy'
+        }
+      }).done(function (response) {
+        var resp = $.parseHTML(response);
+        var $doc = $(resp);
+        var showDocs = $doc.find('article.document');
+        var newDocs = $doc.find('#documents');
+        var sortPerPage = $doc.find('#sortAndPerPage');
+        var pageEntries = sortPerPage.find('.page-entries');
+        var numberEntries = parseInt(pageEntries.find('strong').last().text().replace(/,/g, ''), 10);
+
+        // Hide these until we re-enable in the future
+        sortPerPage.find('.result-type-group').hide();
+        sortPerPage.find('.search-widgets').hide();
+
+        if (!isNaN(numberEntries)) {
+          $('[data-arclight-online-content-tab-count]').html(
+            $(
+              '<span class="badge badge-pill badge-secondary al-online-content-badge">'
+                + numberEntries
+                + '<span class="sr-only">components</span></span>'
+            )
+          );
+        }
+
+        sortPerPage.find('a').on('click', function (e) {
+          var pages = [];
+          var $target = $(e.target);
+          e.preventDefault();
+          pages = /page=(\d+)&/.exec($target.attr('href'));
+          if (pages) {
+            CollectionNavigation.init($el, pages[1]);
+          } else {
+            // Case where the "first" page
+            CollectionNavigation.init($el);
+          }
+        });
+
+        $el.hide().html('').append(sortPerPage).append(newDocs)
+          .fadeIn(50);
+        if (showDocs.length > 0) {
+          $el.trigger('navigation.contains.elements');
+        }
+        Blacklight.doBookmarkToggleBehavior();
+      });
+    }
+  };
+
+  global.CollectionNavigation = CollectionNavigation;
+}(this));
+
+Blacklight.onLoad(function () {
+  'use strict';
+
+  $('.al-contents').each(function (i, element) {
+    CollectionNavigation.init(element); // eslint-disable-line no-undef
+  });
+
+  $('.al-contents').on('navigation.contains.elements', function (e) {
+    var toEnable = $('[data-hierarchy-enable-me]');
+    var srOnly = $('h2[data-sr-enable-me]');
+    toEnable.removeClass('disabled');
+    toEnable.text(srOnly.data('hasContents'));
+    srOnly.text(srOnly.data('hasContents'));
+
+    $(e.target).find('.collapse').on('show.bs.collapse', function (ee) {
+      var $newTarget = $(ee.target);
+      $newTarget.find('.al-contents').each(function (i, element) {
+        CollectionNavigation.init(element); // eslint-disable-line no-undef
+        // Turn off additional ajax requests on show
+        $newTarget.off('show.bs.collapse');
+      });
+    });
+  });
+});


### PR DESCRIPTION
imported `collection_navigation.js` from arclight to override the placeholder element on the collection page, when you open the online content tab:

![Screen Recording 2020-05-01 at 03 09 PM](https://user-images.githubusercontent.com/5492162/80845543-60a9a880-8bbe-11ea-9e79-c16fb95abada.gif)
