### PR TITLE
remove extra logout from admin page

### DIFF
--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -116,10 +116,3 @@
       </div>
     </div>
   </div>
-  
-  
-  <div class="row col mt-4">
-    <%= link_to t('blacklight.header_links.logout'), destroy_user_session_path %>
-  </div>
-</div>
-


### PR DESCRIPTION

# Summary 
Remove extra logout link from admin page

# Related Issue
https://bugs.dlib.indiana.edu/browse/AR-36

# Screenshots / Video
Before:

<img width="615" alt="Screen Shot 2020-05-01 at 3 16 52 PM" src="https://user-images.githubusercontent.com/18175797/80845712-ed546680-8bbe-11ea-90f9-6c7c2fb0824b.png">

After:

<img width="1155" alt="Screen Shot 2020-05-01 at 3 17 00 PM" src="https://user-images.githubusercontent.com/18175797/80845716-f2191a80-8bbe-11ea-838c-8b781d70a994.png">
