### PR TITLE
remove arclight js load

### DIFF
--- a/app/assets/javascripts/arclight.js
+++ b/app/assets/javascripts/arclight.js
@@ -1,5 +1,9 @@
+// COPIED FROM ARCLIGHT TO REMOVE JS FILES THAT ARE LOADING LOCALLY
+
 //= require arclight/collection_scrollspy
-//= require arclight/collection_navigation
+
+// don't load collection navigation file from arclight
+// require arclight/collection_navigation
 
 // don't load context navigation file from arclight
 // require arclight/context_navigation


### PR DESCRIPTION
# Summary 
Staging is broken after merging in JS loader for online contents tab. Looks like the JS is loading both from arclight and locally in the app

<img width="1131" alt="Screen Shot 2020-05-04 at 11 11 14 AM" src="https://user-images.githubusercontent.com/18175797/80998571-07c55480-8df8-11ea-8e35-12d523febd18.png">


