### PR TITLE
Making ArchiveSpace export endpoint configurable

### DIFF
--- a/app/models/ead_processor.rb
+++ b/app/models/ead_processor.rb
@@ -9,7 +9,7 @@ class EadProcessor
 
   # sets the url
   def self.client(args = {})
-    args[:url] || 'https://aspacedev.dlib.indiana.edu/assets/ead_export/'
+    args[:url] || ENV['ASPACE_EXPORT_URL'] || 'http://localhost/assets/ead_export/'
   end
 
   # Open web address with Nokogiri


### PR DESCRIPTION
Adds the ability to override the location of the ArchiveSpace export endpoint via an environment variable.