### PR TITLE
Fixing spec that was broken in AR-57

### DIFF
--- a/spec/models/ead_processor_spec.rb
+++ b/spec/models/ead_processor_spec.rb
@@ -6,7 +6,7 @@ require 'pathname'
 RSpec.describe EadProcessor do
   it 'gets the client without args' do
     client = EadProcessor.client
-    expect(client).to eq 'https://aspacedev.dlib.indiana.edu/assets/ead_export/'
+    expect(client).to eq 'http://localhost/assets/ead_export/'
   end
 
   it 'gets the client with args' do


### PR DESCRIPTION
Fixing spec that was broken in AR-57 when making ASpace export URL configurable. It was literally checking the internal IU URL that was intentionally removed from the EAD Processor.
