### PR TITLE
AR-60 AR-49 Improve homepage access and reroute root to Repositories index

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -8,7 +8,7 @@
       <div class="container">
         <div class="row align-items-center">
           <div class="col-md-8 masthead-center" >
-            <h1><%= t('arclight.masthead_heading') %></h1>
+            <%= link_to t('arclight.masthead_heading'), root_path, class: 'h1' %>
           </div>
 
           <div class="col-md-4 nav-links d-flex justify-content-end" >
@@ -32,7 +32,7 @@
       <div class="container">
         <div class="row align-items-center">
           <div class="col-md-8" >
-            <span class="h1"><%= t('arclight.masthead_heading') %></span>
+            <%= link_to t('arclight.masthead_heading'), root_path, class: 'h1' %>
           </div>
 
           <div class="col-md-4 nav-links d-flex justify-content-end" >

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   mount Blacklight::Engine => '/'
   mount Arclight::Engine => '/'
 
-  root to: 'catalog#index'
+  root to: 'arclight/repositories#index'
   concern :searchable, Blacklight::Routes::Searchable.new
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do


### PR DESCRIPTION
Reroutes the root index to be the Repositories index page.  Makes the main site title a link for consistent access to the home page.