### PR TITLE
AS-66 index single file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,3 +97,4 @@ gem 'whenever', require: false
 gem 'delayed_job_active_record'
 gem "delayed_job_web"
 gem 'omniauth-iu-cas'
+gem 'daemons'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       term-ansicolor
       thor
     crass (1.0.6)
+    daemons (1.3.1)
     database_cleaner (1.8.3)
     delayed_job (4.1.8)
       activesupport (>= 3.0, < 6.1)
@@ -455,6 +456,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   coffee-rails (~> 4.2)
   coveralls
+  daemons
   database_cleaner
   delayed_job_active_record
   delayed_job_web

--- a/app/models/ead_processor.rb
+++ b/app/models/ead_processor.rb
@@ -55,13 +55,13 @@ class EadProcessor
   def self.index_single_ead(args = {})
     repository = args[:repository]
     file_name = args[:ead]
-    link = client(args) + "#{repository}.zip"
+    link = client(args) + "#{repository}/#{file_name}"
     directory = repository.parameterize.underscore
-    open(link, 'rb') do |file|
-      extract_file(file, directory)
-    end
     path = "./data/#{directory}"
+    Dir.mkdir(path) unless Dir.exist?(path)
+    download = open(link, 'rb')
     fpath = File.join(path, file_name)
+    IO.copy_stream(download, fpath)
     filename = File.basename(fpath)
     add_last_indexed(filename, DateTime.now)
     EadProcessor.delay.index_file(fpath, repository)

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,0 +1,1 @@
+Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))


### PR DESCRIPTION
Currently, the ArchiveSpace export lists individual file(s) that may be candidates for indexing because they have changed since the packaged repository Zip files were created.  The EAD processor in ArcLight detects those updated files and highlight them as updated in the Admin panel with the ability to manually index them. However, the method that gets called per file extracts them from the Zip files which do not yet include the updated files.  Since it extracts/indexes the unchanged versions of the files, it gives the appearance that the indexing job fails to update the index.  

This PR changes the manual indexing of a single file to pull the updated XML from ArchiveSpace export site instead of from the repo Zip file. 