### PR TITLE
AS-67 Adds task and methods to just import updated documents

### DIFF
--- a/app/models/ead_processor.rb
+++ b/app/models/ead_processor.rb
@@ -62,7 +62,7 @@ class EadProcessor
         filename = File.basename(fpath)
         zip_file.extract(f, fpath)
         add_last_indexed(filename, DateTime.now)
-        index_file(fpath, directory)
+        EadProcessor.delay.index_file(fpath, directory)
       end
     end
   end

--- a/lib/tasks/import_updated_eads.rake
+++ b/lib/tasks/import_updated_eads.rake
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+desc 'Import and Index EADs'
+task import_updated_eads: :environment do
+  EadProcessor.import_updated_eads
+end


### PR DESCRIPTION
Adding additional Rake task and accompanying methods to just import and index updated documents from the ArchiveSpace export site.  Also changes the method for importing full to use Delayed Job instead of inline.