### PR TITLE
Commenting out Download links

### DIFF
--- a/app/views/catalog/_show_actions_box_default.html.erb
+++ b/app/views/catalog/_show_actions_box_default.html.erb
@@ -22,5 +22,5 @@
     </div>
   </div>
 
-  <%= render document.downloads %>
+  <%# render document.downloads %>
 </div>


### PR DESCRIPTION
Commented out code that provides Download finding aid and Download EAD until we have working download links for both. Collection ID and Aeon Request button still show.