### PR TITLE
AR-64 Adding Solr parameter to sort collections by title

### DIFF
--- a/app/controllers/arclight/repositories_controller.rb
+++ b/app/controllers/arclight/repositories_controller.rb
@@ -17,7 +17,8 @@ module Arclight
       search_service = Blacklight.repository_class.new(blacklight_config)
       @response = search_service.search(
         q: "level_sim:Collection repository_sim:\"#{@repository.name}\"",
-        rows: 100
+        rows: 100,
+        sort: 'title_sort asc'
       )
       @collections = @response.documents
     end


### PR DESCRIPTION
Adds a sort directive to the Solr query for a `Repository`, which forces the default view of a repositories' collections to be alpha sorted.