### PR TITLE
Changing EAD XML to purl for Lilly Aeon

### DIFF
--- a/config/downloads.yml
+++ b/config/downloads.yml
@@ -18,8 +18,8 @@ sample_unitid:
     size: 123456
     # size_accessor: 'level'
 default:
-  disabled: true
+  disabled: false
   pdf:
     template: 'http://example.com/%{unitid}.pdf'
   ead:
-    template: 'http://example.com/%{unitid}.xml'
+    template: 'http://purl.dlib.indiana.edu/iudl/findingaids/%{repository_id}/encodedtext/%{eadid}'


### PR DESCRIPTION
Stops disabling download urls and changes EAD XML url to use PURL with repo id and eadid for finding aid.

Only showing on Lilly Aeon Request button since PDF and EAD download links are still commented out in view.