### PR TITLE
Changing suggest field to not rebuild on commit for performance reasons

### DIFF
--- a/app/jobs/build_suggest_job.rb
+++ b/app/jobs/build_suggest_job.rb
@@ -1,0 +1,18 @@
+require 'net/http'
+
+# Rebuild the Solr suggester index
+# https://lucene.apache.org/solr/guide/8_0/suggester.html
+class BuildSuggestJob
+
+  def self.build_suggest_field
+    # Not using Blacklight.default_index.connection for greater control
+    uri = URI("#{ENV['SOLR_URL']}/suggest?suggest.build=true")
+
+    ::Net::HTTP.start(uri.host, uri.port) do |http|
+      http.read_timeout = 600
+      res = http.request_get(uri.path, 'Accept' => 'application/json')
+      res.value # raises exception if not 2XX status
+      puts res.body
+    end
+  end
+end

--- a/lib/tasks/build_solr_suggest.rake
+++ b/lib/tasks/build_solr_suggest.rake
@@ -1,0 +1,4 @@
+desc 'Build the Solr suggest field'
+task build_solr_suggest: :environment do
+  BuildSuggestJob.build_suggest_field
+end

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -289,7 +289,7 @@
       <str name="indexPath">suggester_infix_dir</str>
       <str name="highlight">false</str>
       <str name="suggestAnalyzerFieldType">text</str>
-      <str name="buildOnCommit">true</str>
+      <str name="buildOnOptimize">true</str>
       <str name="field">suggest</str>
     </lst>
   </searchComponent>


### PR DESCRIPTION
The Solr `suggest` field is rebuilt by default on each commit, which causes exponential growth over time to index documents.  This sets the field to only be rebuilt on optimize, which requires an automated job to trigger.  Also adding a rudimentary job and rake task.