### PR TITLE
Adding Legacy AO links and updating welcome text

### DIFF
--- a/app/views/arclight/repositories/index.html.erb
+++ b/app/views/arclight/repositories/index.html.erb
@@ -7,7 +7,7 @@
 
   <%# ADD CUSTOM CONTENT HERE FOR NGAO REPOSITORY PAGE CONTENT %>
   <h2>Welcome to Archives Online</h2>
-  <p>Archives Online is a portal for accessing descriptions of archival and special collections held by libraries, archives and other cultural heritage units at Indiana University or affiliated with Indiana University. The collection descriptions (finding aids) are for non-book and original research materials such as correspondence and photographs.</p>
+  <p>Archives Online is a portal for accessing descriptions of archival and special collections held by libraries, archives and other cultural heritage units at Indiana University or affiliated with Indiana University. The collection descriptions (finding aids) are for non-book and original research materials such as correspondence and photographs. This new Archive Online site is currently under development and does not yet contain links to digitized materials from collections. To view digitized archival materials, visit <a href="http://www.dlib.indiana.edu/collections/findingaids">Legacy Archives Online</a>.</p>
 
     <%# ADDED CAMPUS LEVEL FOR DISPLAY %>
   <% @campuses.each do |campus, repositories| %>

--- a/app/views/shared/_user_auth_links.html.erb
+++ b/app/views/shared/_user_auth_links.html.erb
@@ -9,4 +9,5 @@
   <li class="nav-item ml-3">
     <%= link_to "Admin", admin_path, class: 'nav-link' %>
   </li>
+  <li class="nav-item ml-3"><a class="nav-link" href="http://www.dlib.indiana.edu/collections/findingaids">Legacy Archives Online</a></li>
 <% end %>


### PR DESCRIPTION
Fixes AR-76

# Summary 
Adds text to Welcome message with link to Legacy Archives Online site. Also adds link in footer across the site that connects to Legacy Archives Online. This appears to the right of Admin or Admin Logout links (if logged in).