### PR TITLE
AR-43 Enable setting of default host and protocol from environment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,10 @@ class ApplicationController < ActionController::Base
   include Blacklight::LocalePicker::Concern
   layout :determine_layout if respond_to? :layout
 
+  def default_url_options(opts={})
+    opts.merge(Ngao::Application.config.action_mailer.default_url_options || {})
+  end
+
   def after_sign_in_path_for(resource)
     stored_location_for(resource) || admin_path
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,5 +59,6 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  config.action_mailer.default_url_options = { protocol: ENV['SITE_PROTOCOL'] || 'http',
+                                               host: ENV['SITE_HOST'] || 'localhost:3000'}
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,7 +103,8 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
   #
-  config.action_mailer.default_url_options = { protocol: 'https', host: ENV['SITE_URL'] }
+  config.action_mailer.default_url_options = { protocol: ENV['SITE_PROTOCOL'] || 'http',
+                                               host: ENV['SITE_HOST'] || 'localhost:3000'}
 
 
   # Do not dump schema after migrations.

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -12,8 +12,8 @@ stdout_redirect 'log/puma.log', 'log/puma.errors', true
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
-daemonize
+port ENV.fetch("PORT") { 3000 }
+# daemonize
 pidfile 'tmp/pids/server.pid'
 
 # Specifies the `environment` that Puma will run in.


### PR DESCRIPTION
When site was deployed as SSL, numerous mixed-content issues were apparent due to default host and protocol not being set.  This allows setting of both from environment variables.

Also turning `daemonize` back off in Puma config to work properly in container.