### PR TITLE
Adding file to change dl style

### DIFF
--- a/app/views/catalog/_show_upper_metadata_default.html.erb
+++ b/app/views/catalog/_show_upper_metadata_default.html.erb
@@ -1,0 +1,14 @@
+<% if blacklight_config.show.component_metadata_partials.present? %>
+  <% parents = Arclight::Parents.from_solr_document(document).as_parents %>
+  <dl class="al-metadata-section">
+    <% blacklight_config.show.component_metadata_partials.each do |metadata| %>
+      <% doc_presenter = show_presenter(document).with_field_group(metadata) %>
+      <% generic_document_fields(metadata).each do |field_name, field| %>
+        <% if generic_should_render_field?(metadata, document, field) %>
+          <dt class="blacklight-<%= field_name.parameterize %>"><%= generic_render_document_field_label(metadata, document, field: field_name) %></dt>
+          <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field %></dd>
+        <% end %>
+      <% end %>
+    <% end %>
+  </dl>
+<% end %>


### PR DESCRIPTION
Fixes AR-79

Removes breadcrumb style calls on <dl> that were causing items to show inline instead of block.