### PR TITLE
AR-80 Remove routes for Bookmarks 

### DIFF
--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,0 +1,8 @@
+<% # overidden from Blacklight to handle our responsive needs %>
+<div id="sortAndPerPage" class="sort-pagination clearfix">
+  <div>
+    <%= render partial: "paginate_compact", object: @response if show_pagination? %>
+  </div>
+  <%= render partial: 'group_toggle'  %>
+  <%= render_results_collection_tools wrapping_class: "search-widgets float-md-right" %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,14 +30,6 @@ Rails.application.routes.draw do
     concerns :exportable
   end
 
-  resources :bookmarks do
-    concerns :exportable
-
-    collection do
-      delete 'clear'
-    end
-  end
-
   get '/admin', to: 'admin#index', as: 'admin'
   get 'admin/index_eads', to: 'admin#index_eads', as: 'index_eads'
   get 'admin/index_repository', to: 'admin#index_repository', as: 'index_repository'


### PR DESCRIPTION
he UI has no links to Bookmarks, but the endpoint is still active.  When an anonymous user (i.e. a bot or security scan) hits '/bookmarks' a guest user account is created in the database.  

Also had to override an Arclight partial that needed the route to invoke a url helper for bookmakrs.