### PR TITLE
Replacing ArcLight with AO at IU in page titles

### DIFF
--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -3,10 +3,13 @@ en:
     masthead_heading: Archives Online
     views:
       about:
-        title: Archives Online - About
+        title: About - Archives Online at Indiana University
       home:
-        title: Archives Online
+        title: Archives Online at Indiana University
       contribute:
-        title: Archives Online - Contribute
+        title: Contribute - Archives Online at Indiana University
       help:
-        title: Archives Online - Help
+        title: Help - Archives Online at Indiana University
+      repositories:
+        show: "%{name} - Archives Online at Indiana University"
+        title: Repositories - Archives Online at Indiana University


### PR DESCRIPTION
Fixes AR-84: Page titles on web site referencing ArcLight

Adds Archives Online at Indiana University for current page titles and adds custom page titles for Repositories pages

Requires app restart to take effect