### PR TITLE
Changed IUPUI campus name to IUPUI

### DIFF
--- a/app/helpers/campus_helper.rb
+++ b/app/helpers/campus_helper.rb
@@ -9,7 +9,7 @@ module CampusHelper
     'US-InU-Se' => 'Indiana University Southeast',
     'US-inrmiue' => 'Indiana University East',
     'US-InU-K' => 'Indiana University Kokomo',
-    'US-iniu' => 'Indiana University-Purdue University, Indianapolis',
+    'US-iniu' => 'IUPUI',
     'US-InU-N' => 'Indiana University Northwest'
   }
 


### PR DESCRIPTION
Fixes AR-96: Change campus name Indiana University-Purdue University, Indianapolis to IUPUI

Requires app restart. No finding aids indexed for repos in IUPUI on dev so unable to verify that campus faceting updates accordingly, but it should.