### PR TITLE
Adding tasks to purge all docs from DB and Solr

### DIFF
--- a/app/models/ead_processor.rb
+++ b/app/models/ead_processor.rb
@@ -61,6 +61,7 @@ class EadProcessor
         File.delete(fpath) if File.exist?(fpath)
         filename = File.basename(fpath)
         zip_file.extract(f, fpath)
+        add_ead_to_db(filename, directory)
         add_last_indexed(filename, DateTime.now)
         EadProcessor.delay.index_file(fpath, directory)
       end

--- a/lib/tasks/clear_eads_history.rake
+++ b/lib/tasks/clear_eads_history.rake
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+desc 'Clear database entries for EADs to clear indexing history'
+task clear_eads_history: :environment do
+  Ead.delete_all
+end

--- a/lib/tasks/purge_and_index_docs.rake
+++ b/lib/tasks/purge_and_index_docs.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+desc 'Clear EAD indexing history, destroy Solr docs, import all from AS'
+task purge_and_index_docs: :environment do
+  Rake::Task["clear_eads_history"].execute
+  Rake::Task["arclight:destroy_index_docs"].execute
+  Rake::Task["import_eads"].execute
+end


### PR DESCRIPTION
Adds new Rake tasks to purge docs from both the database (i.e. tracking of indexing status) and Solr.