### PR TITLE
Adds Unit ID to search drop down menu

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -190,6 +190,13 @@ class CatalogController < ApplicationController
         pf:  '${pf_title}'
       }
     end
+    config.add_search_field 'unitid', label: 'Unit ID' do |field|
+      field.qt = 'search'
+      field.solr_parameters = {
+        qf:  '${qf_unitid}',
+        pf:  '${pf_unitid}'
+      }
+    end
 
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the SOLR field to sort by and

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -334,6 +334,7 @@
    <copyField source="places_ssm" dest="place_tesim"/>
    <copyField source="names_ssim" dest="name_tesim"/>
    <copyField source="access_subjects_ssim" dest="subject_tesim"/>
+   <copyField source="unitid_ssm" dest="unitid_tesim"/>
 
    <!-- The catch all `text` field -->
    <!-- grab the fielded searches -->

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -127,6 +127,12 @@
        <str name="pf_title">
          title_tesim
        </str>
+       <str name="qf_unitid">
+         unitid_tesim
+       </str>
+       <str name="pf_unitid">
+         unitid_tesim
+       </str>
 
        <int name="ps">3</int>
        <float name="tie">0.01</float>

--- a/spec/features/search_dropdown_spec.rb
+++ b/spec/features/search_dropdown_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Search Dropdown', type: :feature do
+  context 'on regular search queries' do
+    it 'lists expected fields' do
+      visit search_catalog_path q: 'a brief', search_field: 'all_fields'
+      within '#search_field' do
+        expect(page).to have_content 'All Fields'
+        expect(page).to have_content 'Keyword'
+        expect(page).to have_content 'Name'
+        expect(page).to have_content 'Place'
+        expect(page).to have_content 'Subject'
+        expect(page).to have_content 'Title'
+        expect(page).to have_content 'Unit ID'
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Summary 
Unit ID field was added to the search drop down menu.  

# Related Issue
[#AR-72](https://bugs.dlib.indiana.edu/browse/AR-72)

# Expected Behavior

A user may search for full or partial Unit IDs and will be returned matching records.

# Screenshots / Video
<details>

## Video

https://user-images.githubusercontent.com/36549923/106943037-c0972780-66d9-11eb-8013-49ee4d43cb09.mov



## Screenshot
![image](https://user-images.githubusercontent.com/36549923/106942365-f687dc00-66d8-11eb-9fcf-905e2b36d8da.png)

</details>

# Dependencies

N/A

# Side Effects

Test suite and manual testing revealed no side effects.

# Testing / Reproduction instructions

Step by step instructions on how to test this feature. Include links and username/passswords if necessary. Videos are especially helpful. Also, name any spec files that should be run for this feature, or to test any side effects from this feature.

1. Go to home page
2. Search for Unit IDs (ex. PC002)
3. Expect matching records for Unit ID (ex. Test Change Jesse James Galloway...)

# Deployment

Will be deployed to staging for QA.

# Other Information

N/A