### PR TITLE
increased boosting for collection title

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -85,7 +85,7 @@
        -->
 
        <str name="qf">
-         collection_title_tesim^150
+         collection_title_tesim^500
          title_tesim^100
          name_tesim^10
          place_tesim^10
@@ -94,7 +94,7 @@
          text
        </str>
        <str name="pf">
-         collection_title_tesim^150
+         collection_title_tesim^500
          title_tesim^100
          name_tesim^10
          place_tesim^10


### PR DESCRIPTION
Fixes first part of #ar87; https://bugs.dlib.indiana.edu/browse/AR-87

# Summary 
Search in Title for “Patten Foundation” (in all repositories). You get 24 hits but the finding aid for the Patten Foundation records themselves don’t show up until the last page of the search results. 

# Related Issue
https://bugs.dlib.indiana.edu/browse/AR-87

# Expected Behavior

When searching for text that appears in a collection title, the collection should appear at the top of the search results

# Screenshots / Video

![image](https://user-images.githubusercontent.com/18175797/106949456-d14b9b80-66e1-11eb-94b9-1eb4c868752a.png)

# Testing / Reproduction instructions

1. Perform a search for text in a collection title
2. Make sure the collection is at the top or near the top of the search results

# Deployment

To be deployed to notch8 staging for testing

https://ngao-staging-web.notch8.cloud/

# Other Information

This fix requires reindexing of the content