### PR TITLE
Hides not selectable option from drop down menu

### DIFF
--- a/app/assets/stylesheets/iu-branding.scss
+++ b/app/assets/stylesheets/iu-branding.scss
@@ -58,6 +58,13 @@ a:hover {
 .btn-primary:focus, .btn-primary.focus {
   background-color: $iu-mahogany;
 }
+
+// within collection search drop down
+// hides 'this collection' when not selectable
+#within_collection option:disabled {
+  display: none;
+}
+
 // facet colors
 .card {
   background-color: $iu-cream;


### PR DESCRIPTION
# Summary 
When outside of a single collection, "This collection" showed as an option in the drop-down menu of the search form but it was not selectable. This option has been hidden.

# Related Issue
[#AR-93](https://bugs.dlib.indiana.edu/browse/AR-93)

# Expected Behavior

* "This collection" does not show when it is not an option
*  When it is an option, it is the default selection and "All collections" is still available as another option

# Screenshots / Video
<details>

## Video
https://user-images.githubusercontent.com/36549923/106967556-38764980-66fc-11eb-8e80-8bb6aed115d6.mov

## Screenshots
### Within Collection
![image](https://user-images.githubusercontent.com/36549923/106967203-9eae9c80-66fb-11eb-88e3-cca215e783d9.png)

### Outside Collection
![image](https://user-images.githubusercontent.com/36549923/106967290-c30a7900-66fb-11eb-8354-747b26efec2c.png)

</details>

# Testing / Reproduction instructions

Step by step instructions on how to test this feature. Include links and username/passswords if necessary. Videos are especially helpful. Also, name any spec files that should be run for this feature, or to test any side effects from this feature.

1. Visit homepage
2. Click collection drop down
3. Observe `this collection` no longer appears

# Deployment

Will be deployed to staging for QA.
