### PR TITLE
Adds autocomplete to repository search

### DIFF
--- a/app/controllers/arclight/repositories_controller.rb
+++ b/app/controllers/arclight/repositories_controller.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
 ##### COPIED FROM ARCLIGHT TO ADD CAMPUS LEVEL #####
-
+# Added search suggest config 
 module Arclight
   # Controller for our /repositories index page
   ##### Added group by campus and sorting alphabetically for campus and repository #####
   class RepositoriesController < ApplicationController
+    # Copied L10-15 from Blacklight Catalog Controller v7.11.1 to include search suggest 
+    include Blacklight::Catalog
+    configure_blacklight do |config|
+      # Configuration for autocomplete suggestor
+      config.autocomplete_enabled = true
+      config.autocomplete_path = 'suggest'
+    end
+
     def index
       @repositories = Arclight::Repository.all
       @campuses = @repositories.sort_by{ |repository| repository.name }.group_by{ |campus| campus.campus }.sort

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,11 @@ Rails.application.routes.draw do
     concerns :range_searchable
   end
 
+  resource :repositories, as: 'repositories', path: '/catalog', controller: 'arclight/repositories' do
+    concerns :searchable
+    concerns :range_searchable
+  end
+
   devise_for :users, controllers: { sessions: 'users/sessions', omniauth_callbacks: "users/omniauth_callbacks" },
              skip: [:sessions, :passwords, :registration]
   # devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }


### PR DESCRIPTION
# Summary 
Typeahead autocomplete function enabled on search bar from repositories page.

# Related Issue
#AR-87 

# Screenshots / Video
<details>
![image](https://user-images.githubusercontent.com/36549923/107686788-80e0ba80-6c5a-11eb-8ee8-b9b631da1815.png)
</details>