### PR TITLE
Prevents loading of duplicate js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,14 +21,12 @@
 //= require twitter/typeahead
 //= require bootstrap
 //= require blacklight/blacklight
-// Required by Arclight
-//= require arclight/arclight
+//= require arclight
 //= require stickyfill
 
-//= require_tree .
+//= require collection_navigation
 
 
 // For blacklight_range_limit built-in JS, if you don't want it you don't need
 // this:
 //= require 'blacklight_range_limit'
-

--- a/app/assets/javascripts/arclight.js
+++ b/app/assets/javascripts/arclight.js
@@ -6,7 +6,7 @@
 // require arclight/collection_navigation
 
 // load overridden local file
-// require context_navigation
+//= require context_navigation
 
 //= require arclight/oembed_viewer
 //= require arclight/truncator

--- a/app/assets/javascripts/arclight.js
+++ b/app/assets/javascripts/arclight.js
@@ -5,8 +5,8 @@
 // don't load collection navigation file from arclight
 // require arclight/collection_navigation
 
-// don't load context navigation file from arclight
-// require arclight/context_navigation
+// load overridden local file
+// require context_navigation
 
 //= require arclight/oembed_viewer
 //= require arclight/truncator


### PR DESCRIPTION
# Summary
Context navigation Javascript was loaded twice causing a syntax error and preventing successful compilation of assets for test instances.  This PR cleans up the included Javascript assets.