### PR TITLE
Styles modal pagination links

### DIFF
--- a/app/assets/stylesheets/iu-branding.scss
+++ b/app/assets/stylesheets/iu-branding.scss
@@ -145,3 +145,9 @@ li.al-collection-context .al-online-content-icon svg,
 .btn:disabled, .btn.disabled {
   background-color: $iu-mahogany;
 }
+
+// custom next previous in more modal
+.prev_next_links .btn.disabled {
+  background-color: $iu-white;
+  color: $iu-grey;
+}

--- a/app/assets/stylesheets/iu_variables.scss
+++ b/app/assets/stylesheets/iu_variables.scss
@@ -1,3 +1,5 @@
 $iu-crimson: #990000;
 $iu-mahogany: #4A3C31;
 $iu-cream: #EDEBEB;
+$iu-white: #FFF;
+$iu-grey: #A9A9A9;


### PR DESCRIPTION
# Summary 
Remove brown background from previous and next buttons in 'more' modal.

# Related Issue
[AR-59](https://bugs.dlib.indiana.edu/browse/AR-59)

# Screenshots / Video
<details>

![image](https://user-images.githubusercontent.com/36549923/108257439-9ef36280-7113-11eb-8151-584744b9c3cf.png)

</details>