### PR TITLE
Changes route for start over link

### DIFF
--- a/app/views/catalog/_start_over.html.erb
+++ b/app/views/catalog/_start_over.html.erb
@@ -1,0 +1,2 @@
+<%# COPIED FROM BLACKLIGHT v7.11.1 TO REPLACE PATH %>
+<%= link_to t('blacklight.search.start_over'), root_path, class: "catalog_startOverLink btn btn-primary" %>

--- a/spec/features/start_over_spec.rb
+++ b/spec/features/start_over_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Start Over', type: :feature do
   context 'from catalog search' do
     it 'has correct url' do
       visit search_catalog_path q: 'a brief', search_field: 'all_fields'
-      expect(page).to have_link("Start Over", :href=>"/")
+      expect(page).to have_link('Start Over', href: '/')
     end
   end
 end

--- a/spec/features/start_over_spec.rb
+++ b/spec/features/start_over_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Start Over', type: :feature do
+  context 'from catalog search' do
+    it 'has correct url' do
+      visit search_catalog_path q: 'a brief', search_field: 'all_fields'
+      expect(page).to have_link("Start Over", :href=>"/")
+    end
+  end
+end


### PR DESCRIPTION
# Summary
Changes 'Start Over' link to visit root path / repositories home page rather than the catalog home page.

# Related Ticket
[AR-78](https://bugs.dlib.indiana.edu/browse/AR-78)

# Video

https://user-images.githubusercontent.com/36549923/109070275-235f5b80-76a7-11eb-8756-990191351ca1.mov

