### PR TITLE
Adds suggest route for autocomplete

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,0 +1,43 @@
+<% 
+# Copied from ArcLight at commit 57dc0ae to specify suggest path for autocomplete
+# This file can be removed once new ArcLight ( > 0.4.0) release is available 
+%>
+
+<%
+# Overridden from Blacklight to add a drop down that allows the user to choose to search w/i the collection or all collections
+%>
+<%= form_tag search_action_url, method: :get, class: 'search-query-form pr-0', role: 'search' do %>
+  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8).merge(f: (search_state.params_for_search[:f] || {}).except(:collection_sim))) %>
+  <div class="d-md-flex">
+    <%= render 'catalog/within_collection_dropdown' %>
+
+    <% if search_fields.length > 1 %>
+      <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
+    <% end %>
+    <div class="input-group flex-nowrap">
+      <% if search_fields.length > 1 %>
+          <%= select_tag(:search_field,
+                         options_for_select(search_fields, h(params[:search_field])),
+                         title: t('blacklight.search.form.search_field.title'),
+                         id: "search_field",
+                         class: "custom-select search-field") %>
+      <% elsif search_fields.length == 1 %>
+        <%= hidden_field_tag :search_field, search_fields.first.last %>
+      <% end %>
+
+      <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
+      <%
+        # Use "autocomplete_path: suggest_index_catalog_path" explicitly so that the RepositoriesController gets the appropriate
+        # autocomplete path w/o having to have the search form action be local to the controller (by including Blacklight::Catalog)
+      %>
+      <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q rounded-0 form-control", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: suggest_index_catalog_path }  %>
+
+      <span class="input-group-append">
+        <button type="submit" class="btn btn-primary search-btn" id="search">
+          <span class="submit-search-text d-none d-lg-inline"><%= t('blacklight.search.form.submit') %></span>
+          <%= blacklight_icon :search, aria_hidden: true %>
+        </button>
+      </span>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
Fixes part of #AR-87

# Summary 
A short description of the feature

# Related Issue
[AR-87 Section 2](https://bugs.dlib.indiana.edu/browse/AR-87)

# Expected Behavior
From repositories page a user can type and see autocomplete suggestions

# Screenshots / Video

https://user-images.githubusercontent.com/36549923/109079060-38da8280-76b3-11eb-8aab-17b9e00ab8c0.mov



# Dependencies

No, but once a new release of ArcLight ( > 0.4.0) is published this app can be upgraded and the partial can be removed.

# Side Effects

N/A

# Testing / Reproduction instructions

1. Visit `/repositories`
2. Type into search form
3. Observe autocomplete suggestions

# Deployment
To be deployed to Notch8 staging for demo and qa