### PR TITLE
pinned version of solr_wrapper due to errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'arclight'
 gem 'blacklight_range_limit', '~> 7.1'
 group :development, :test do
-  gem 'solr_wrapper', '>= 0.3'
+  gem 'solr_wrapper', '3.1.1'
   gem 'nulldb'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,8 +361,8 @@ GEM
       rack-protection (= 2.1.0)
       tilt (~> 2.0)
     slop (4.8.2)
-    solr_wrapper (2.2.0)
-      faraday
+    solr_wrapper (3.1.1)
+      http
       retriable
       ruby-progressbar
       rubyzip
@@ -484,7 +484,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   shoulda-matchers
   simplecov
-  solr_wrapper (>= 0.3)
+  solr_wrapper (= 3.1.1)
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3


### PR DESCRIPTION
solr_wrapper version 2.2.0 was causing errors starting up so we upgraded the version.