### PR TITLE
AR-92 Add counter to search result pages

### DIFF
--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -327,6 +327,15 @@ module ArclightHelper
     controller_name == 'catalog' && action_name == 'show'
   end
 
+  ##
+  # Get the counter for a document - used for grouped index views
+  #
+  # @param [Integer] idx document index
+  # @return [Integer]
+  def document_counter(idx)
+    idx + 1
+  end
+
   private
 
     def build_repository_link(document)

--- a/app/views/catalog/_arclight_index_compact_default.html.erb
+++ b/app/views/catalog/_arclight_index_compact_default.html.erb
@@ -1,0 +1,30 @@
+<%# COPIED FROM ARCLIGHT TO ADD NUMBERING TO SEARCH RESULTS %>
+<div class="documentHeader row">
+  <% counter = document_counter_with_offset(document_counter) %>
+  <div class="col-auto">
+    <%= blacklight_icon document_or_parent_icon(document) %>
+  </div>
+  <div class="col col-no-left-padding col-no-right-padding">
+    <div class="d-flex justify-content-between">
+      <h3 class="col col-no-left-padding">
+        <%# ADDED NUMBERING TO SEARCH RESULTS %>
+        <% if counter = document_counter_with_offset(document_counter) %>
+          <span class="document-counter">
+            <%= t('blacklight.search.documents.counter', counter: counter) %>
+          </span>
+        <% end %>
+        <%= link_to_document document, document_show_link_field(document), counter: document_counter %>
+      </h3>
+      <%= render_index_doc_actions document %>
+    </div>
+    <div class="row">
+      <%= content_tag('div', class: 'al-document-highlight col') do %>
+        <%= document.highlights.join('<br/>').html_safe %>
+      <% end if document.highlights %>
+    </div>
+    <div class='breadcrumb-links media'>
+      <span class="media-body" aria-hidden="true"><%= blacklight_icon :repository, classes: 'al-repository-content-icon' %></span>
+    <span class="col ml-2 pl-0" ><%= regular_compact_breadcrumbs(document) %></span>
+    </div>
+  </div>
+</div>

--- a/app/views/catalog/_arclight_index_default.html.erb
+++ b/app/views/catalog/_arclight_index_default.html.erb
@@ -1,0 +1,52 @@
+<%# COPIED FROM ARCLIGHT TO ADD NUMBERING TO SEARCH RESULTS %>
+<div class="al-search-result-index-article row d-flex align-items-start">
+  <% counter = document_counter_with_offset(document_counter) %>
+  <div class="col-auto">
+    <%= render partial: 'arclight_document_header_icon', locals: { document: document }  %>
+  </div>
+
+  <div class="col col-no-left-padding d-flex flex-wrap">
+    <div class="documentHeader my-w-75 w-md-100 order-0" data-document-id="<%= document.id %>">
+      <h3 class="index_title document-title-heading">
+        <%# ADDED NUMBERING TO SEARCH RESULTS %>
+        <% if counter = document_counter_with_offset(document_counter) %>
+          <span class="document-counter">
+            <%= t('blacklight.search.documents.counter', counter: counter) %>
+          </span>
+        <% end %>
+        <%= link_to_document document, document_show_link_field(document), counter: counter %>
+        <%= content_tag('span', class: 'al-document-extent badge') do %>
+          <%= document.extent %>
+        <% end if document.extent %>
+      </h3>
+    </div>
+
+    <div class="my-w-25 w-md-100 order-12 order-md-1">
+      <%= render_index_doc_actions document, wrapping_class: 'd-flex justify-content-end' %>
+    </div>
+
+    <div class="order-2">
+      <div class="row">
+        <%= content_tag('div', class: 'al-document-highlight col') do %>
+          <%= document.highlights.join('<br/>').html_safe %>
+        <% end if document.highlights %>
+      </div>
+
+      <div class="row">
+        <%= content_tag('div', class: 'al-document-creator col') do %>
+          <%= document.creator %>
+        <% end if document.creator %>
+      </div>
+
+      <div class="row">
+        <%= content_tag('div', class: 'al-document-abstract-or-scope col') do %>
+          <%= content_tag('div', 'data-arclight-truncate' => true) do %>
+            <%= document.abstract_or_scope %>
+          <% end %>
+        <% end if document.abstract_or_scope %>
+      </div>
+
+      <%= render partial: 'index_breadcrumb_default', locals: { document: document } %>
+    </div>
+  </div>
+</div>

--- a/app/views/catalog/_arclight_index_group_document_compact_default.html.erb
+++ b/app/views/catalog/_arclight_index_group_document_compact_default.html.erb
@@ -1,0 +1,27 @@
+<%# COPIED FROM ARCLIGHT TO ADD NUMBERING TO SEARCH RESULTS %>
+<article class="document">
+  <% counter = document_counter(document_counter) %>
+  <% breadcrumbs = component_top_level_parent_to_links(document) %>
+  <div class="documentHeader row">
+    <div class="col-auto">
+      <%= blacklight_icon document_or_parent_icon(document) %>
+    </div>
+    <div class="col col-no-left-padding">
+      <h4>
+        <%# ADDED NUMBERING TO SEARCH RESULTS %>
+        <% if counter = document_counter(document_counter) %>
+          <span class="document-counter">
+            <%= t('blacklight.search.documents.counter', counter: counter) %>
+          </span>
+        <% end %>
+        <%= link_to_document document, document_show_link_field(document), counter: document_counter %>
+      </h4>
+      <div class='breadcrumb-links media'>
+        <% unless breadcrumbs.nil? %>
+          <span class="media-body" aria-hidden="true"><%= blacklight_icon :folder, classes: 'al-folder-icon' %></span>
+          <span class="col" ><%= component_top_level_parent_to_links(document) %></span>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</article>

--- a/app/views/catalog/_arclight_index_group_document_default.html.erb
+++ b/app/views/catalog/_arclight_index_group_document_default.html.erb
@@ -1,0 +1,26 @@
+<%# COPIED FROM ARCLIGHT TO ADD NUMBERING TO SEARCH RESULTS %>
+<article class="document">
+  <% counter = document_counter(document_counter) %>
+  <% breadcrumbs = parents_to_links(document) %>
+  <div class="documentHeader row">
+    <div class="col-auto">
+      <%= blacklight_icon document_or_parent_icon(document) %>
+    </div>
+    <div class="col col-no-left-padding">
+      <h4>
+        <%# ADDED NUMBERING TO SEARCH RESULTS %>
+        <% if counter = document_counter(document_counter) %>
+          <span class="document-counter">
+            <%= t('blacklight.search.documents.counter', counter: counter) %>
+          </span>
+        <% end %>
+        <%= link_to_document document, document_show_link_field(document), counter: document_counter %>
+      </h4>
+      <div class='breadcrumb-links media'>
+        <% unless breadcrumbs.nil? %>
+          <span class="media-body" aria-hidden="true"><%= blacklight_icon :folder, classes: 'al-folder-icon' %></span>
+          <span class="col" ><%= parents_to_links(document) %></span>
+        <% end %>
+    </div>
+  </div>
+</article>

--- a/spec/helpers/arclight_helper_spec.rb
+++ b/spec/helpers/arclight_helper_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ArclightHelper, type: :helper do
+  describe 'document_counter' do
+    it 'renders the document index with the appropriate counter' do
+      assign(:response, instance_double(Blacklight::Solr::Response, start: 0))
+      expect(helper.document_counter(0)).to be(1)
+      expect(helper.document_counter(1)).to be(2)
+    end
+  end
+end


### PR DESCRIPTION

# Summary 
Add numbering to the items on each of the search results pages

- 	search index
- 	search index compact view
- 	grouped search index
- 	grouped search index compact view

> When you're looking at All results, the results should be numbered 1-x, continuing with each page. (eg 1-10 on the first page, 11-20 on the second, etc.)
> 
> When you look at Grouped by collection, the numbering should restart with each collection.

# Related Issue
https://bugs.dlib.indiana.edu/browse/AR-92

# Expected Behavior

When viewing search results, the items should be numbered

# Screenshots / Video
Search index:
<details>
![index](https://user-images.githubusercontent.com/18175797/111710649-5230a380-8807-11eb-8f78-f973a4f247c8.png)

</details>

Search index compact:
<details>
![index-compact](https://user-images.githubusercontent.com/18175797/111710693-62e11980-8807-11eb-8ef3-866d2f1334dd.png)
</details>

Grouped search index:
<details>
![grouped-index](https://user-images.githubusercontent.com/18175797/111710670-58268480-8807-11eb-8a25-3931c5d822e7.png)
</details>

Grouped search index compact:
<details>
![grouped-compact-index](https://user-images.githubusercontent.com/18175797/111710864-c23f2980-8807-11eb-8400-03d19f5928b4.png)

</details>

# Deployment

To be deployed to Notch8 staging for demo
