### PR TITLE
DRAFT: AR-90 Adds generated purl link

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -272,6 +272,7 @@ class CatalogController < ApplicationController
     config.add_summary_field 'abstract_ssm', label: 'Abstract', helper_method: :render_html_tags
     config.add_summary_field 'extent_ssm', label: 'Extent'
     config.add_summary_field 'language_ssm', label: 'Language'
+    config.add_summary_field 'purl_ssi', label: 'Permanent URL', helper_method: :link_to_url
     config.add_summary_field 'prefercite_ssm', label: 'Preferred citation', helper_method: :render_html_tags
 
     # Collection Show Page - Background Section

--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -309,6 +309,11 @@ module ArclightHelper
     )
   end
 
+  # Custom show page method for displaying links
+  def link_to_url(arg)
+    link_to(arg[:value][0], arg[:value][0])
+  end
+
   ##
   # Determine if the user is currently under a collection context
   # This is any record view (because it is either the collection or a component w/i a collection)

--- a/lib/ngao-arclight/traject/ead2_config.rb
+++ b/lib/ngao-arclight/traject/ead2_config.rb
@@ -206,7 +206,7 @@ end
 
 to_field 'purl_ssi' do |_record, accumulator, context|
   repo_name = settings['repository']
-  ead_number = context.output_hash['ead_ssi'].first.split('-').last
+  ead_number = context.output_hash['ead_ssi'].first
   accumulator << "http://purl.dlib.indiana.edu/iudl/findingaids/#{repo_name}/#{ead_number}"
 end
 

--- a/lib/ngao-arclight/traject/ead2_config.rb
+++ b/lib/ngao-arclight/traject/ead2_config.rb
@@ -204,6 +204,12 @@ to_field 'digital_objects_ssm', extract_xpath('/ead/archdesc/did/dao|/ead/archde
   end
 end
 
+to_field 'purl_ssi' do |_record, accumulator, context|
+  repo_name = settings['repository']
+  ead_number = context.output_hash['ead_ssi'].first.split('-').last
+  accumulator << "http://purl.dlib.indiana.edu/iudl/findingaids/#{repo_name}/#{ead_number}"
+end
+
 to_field 'extent_ssm', extract_xpath('/ead/archdesc/did/physdesc', to_text: false) do |_record, accumulator|
   accumulator.map! do |element|
     extent_array = []

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -60,5 +60,9 @@ RSpec.describe 'EAD 2 traject indexing', type: :feature do
     it 'indexes extents contained within a single physdesc as one string' do
       expect(result['extent_ssm']).to eq ['184 items ((1 box))', '8.15 cubic feet (One full-size records case, one letter-size documents case, twenty-six shelved books, and oversize material in flat storage.)']
     end
+
+    it 'generates a purl link' do
+      expect(result['purl_ssi']).to eq ['http://purl.dlib.indiana.edu/iudl/findingaids/lilly/VAD6017']
+    end
   end
 end

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'generates a purl link' do
-      expect(result['purl_ssi']).to eq ['http://purl.dlib.indiana.edu/iudl/findingaids/lilly/VAD6017']
+      expect(result['purl_ssi']).to eq ['http://purl.dlib.indiana.edu/iudl/findingaids/lilly/InU-Li-VAD6017']
     end
   end
 end


### PR DESCRIPTION
Fixes [#AR-90](https://bugs.dlib.indiana.edu/browse/AR-90)

# Summary 
Adds a generated PURL link to the summary section of the collection metadata.

# Screenshots / Video
<details>

![image](https://user-images.githubusercontent.com/36549923/112519368-8a7c3880-8d57-11eb-9b54-9f773b7ce48e.png)
![image](https://user-images.githubusercontent.com/36549923/112519506-abdd2480-8d57-11eb-93fa-baa6ad2f6ce2.png)
</details>

# Deployment
Will be deployed to Notch8 staging for testing