### PR TITLE
DRAFT: AR-87 Removes typeahead suggestions when within collection

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,6 +1,5 @@
 <% 
 # Copied from ArcLight at commit 57dc0ae to specify suggest path for autocomplete
-# This file can be removed once new ArcLight ( > 0.4.0) release is available 
 %>
 
 <%
@@ -26,11 +25,31 @@
       <% end %>
 
       <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
+
       <%
-        # Use "autocomplete_path: suggest_index_catalog_path" explicitly so that the RepositoriesController gets the appropriate
-        # autocomplete path w/o having to have the search form action be local to the controller (by including Blacklight::Catalog)
+        # Customizes autocomplete for within collection scope
       %>
-      <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q rounded-0 form-control", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: suggest_index_catalog_path }  %>
+      <% if within_collection_context? %>
+        <%= text_field_tag :q, 
+                          params[:q], 
+                          placeholder: t('blacklight.search.form.search.placeholder'), 
+                          class: "search-q q rounded-0 form-control", 
+                          id: "q", 
+                          autofocus: presenter.autofocus?, 
+                          data: { autocomplete_enabled: false }  %>
+      <% else %>
+        <%
+          # Use "autocomplete_path: suggest_index_catalog_path" explicitly so that the RepositoriesController gets the appropriate
+          # autocomplete path w/o having to have the search form action be local to the controller (by including Blacklight::Catalog)
+        %>
+        <%= text_field_tag :q, 
+                          params[:q], 
+                          placeholder: t('blacklight.search.form.search.placeholder'), 
+                          class: "search-q q rounded-0 form-control", 
+                          id: "q", 
+                          autofocus: presenter.autofocus?, 
+                          data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: suggest_index_catalog_path }  %>
+      <% end %>
 
       <span class="input-group-append">
         <button type="submit" class="btn btn-primary search-btn" id="search">


### PR DESCRIPTION
# Summary 
Typeahead suggestions should not appear when inside a collection.

# Related Issue
[AR-87](https://bugs.dlib.indiana.edu/browse/AR-87)

# Expected Behavior

* Within collection - only suggests what is stored in the user's browser
* Outside of collection - typeahead supplies relevant suggestions 

# Screenshots / Video
<details>

![image](https://user-images.githubusercontent.com/36549923/112529213-42aede80-8d62-11eb-989c-eef49b019c4f.png)

![image](https://user-images.githubusercontent.com/36549923/112528953-fa8fbc00-8d61-11eb-9230-56b9ab57c95c.png)

</details>

# Deployment
Will be deployed to Notch8 staging for testing.

