### PR TITLE
Fixing GitHub Action due to deprecation of insecure action

### DIFF
--- a/.github/workflows/dockerimage_test.yml
+++ b/.github/workflows/dockerimage_test.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Get branch name
       id: get_branch
-      run: echo ::set-env name=BRANCH_NAME::$(echo ${GITHUB_REF:11})
+      run: echo "BRANCH_NAME=$(echo ${GITHUB_REF:11})" >> $GITHUB_ENV
     - name: Build and push to Docker Hub
       uses: elgohr/Publish-Docker-Github-Action@master
       with:


### PR DESCRIPTION
Use of set-env inside GitHub Action workflows was causing image build failure.  Changed to use a transient environment file syntax.