### PR TITLE
AR-69 Update Icons

### DIFF
--- a/app/assets/images/blacklight/arrow-return-right.svg
+++ b/app/assets/images/blacklight/arrow-return-right.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-return-right" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M1.5 1.5A.5.5 0 0 0 1 2v4.8a2.5 2.5 0 0 0 2.5 2.5h9.793l-3.347 3.346a.5.5 0 0 0 .708.708l4.2-4.2a.5.5 0 0 0 0-.708l-4-4a.5.5 0 0 0-.708.708L13.293 8.3H3.5A1.5 1.5 0 0 1 2 6.8V2a.5.5 0 0 0-.5-.5z"/>
+</svg>

--- a/app/views/catalog/_index_collection_context_default.html.erb
+++ b/app/views/catalog/_index_collection_context_default.html.erb
@@ -1,0 +1,53 @@
+
+<%# COPIED FROM ARCLIGHT TO REMOVE ICON FROM COLLECTION CONTEXT %>
+<li id="<%= document.id %>" class="al-collection-context row d-flex align-items-start">
+  <div class="documentHeader row" data-document-id="<%= document.id %>">
+    <% requestable = item_requestable?('', { document: document }) %>
+    <% if document.children? %>
+      <div class="al-toggle-children-container">
+        <%= link_to(
+          '',
+          "##{document.id}-collapsible-hierarchy",
+          class: "al-toggle-view-children #{!show_expanded?(document) ? 'collapsed' : ''}",
+          'aria-label': t('arclight.hierarchy.view_all'),
+            data: {
+              toggle: 'collapse'
+            }
+          )
+        %>
+      </div>
+    <% end %>
+    <%# REMOVE ICON FROM COLLECTION CONTEXT %>    
+    <div class="col col-no-left-padding d-flex flex-wrap">
+      <div class="index_title document-title-heading my-w-75 w-md-100 order-0">
+        <% counter = document_counter_with_offset(document_counter) %>
+        <%= link_to_document document, document_show_link_field(document), counter: counter %>
+        <% if document.children? %>
+          <span class="badge badge-pill badge-secondary al-number-of-children-badge"><%= document.number_of_children %><span class="sr-only"><%= t(:'arclight.views.index.number_of_components', count: document.number_of_children) %></span></span>
+        <% end %>
+      </div>
+      
+      <div class="my-w-25 w-md-100 order-12 order-md-1">
+        <%= render_index_doc_actions document, wrapping_class: 'd-flex justify-content-end' %>
+      </div>
+
+      <div class="order-2">
+        <div class="row">
+          <%= content_tag('div', class: 'al-document-abstract-or-scope mb-0') do %>
+            <%= content_tag('div', data: { 'arclight-truncate': true, 'truncate-more': I18n.t('arclight.truncation.view_more'), 'truncate-less': I18n.t('arclight.truncation.view_less') } ) do %>
+              <%= document.abstract_or_scope %>
+            <% end %>
+          <% end if document.abstract_or_scope %>
+        </div>
+      </div>
+    </div>
+  </div>
+  <% if document.number_of_children > 0 %>
+    <%= content_tag(:div, id: "#{document.id}-collapsible-hierarchy",
+      class: "collapse al-collection-context-collapsible al-hierarchy-level-#{document.component_level} #{'show' if show_expanded?(document)}",
+      data: { resolved: false }
+    ) do %>
+      <%= generic_context_navigation(document, component_level: document.component_level + 1, original_parents: params[:original_parents]) %>
+    <% end %>
+  <% end %>
+</li>

--- a/app/views/shared/_show_breadcrumbs.html.erb
+++ b/app/views/shared/_show_breadcrumbs.html.erb
@@ -27,14 +27,14 @@
     </li>
     <% parents.each_with_index.map do |parent, index| %>
       <%= content_tag :li, class: "breadcrumb-item breadcrumb-item-#{index + 3} media" do %>
-        <span class="media-body" aria-hidden="true"><%= blacklight_icon document_or_parent_icon(parent) %></span>
+        <span class="media-body" aria-hidden="true"><%= blacklight_icon "arrow-return-right" %></span>
         <span class="col"><%= link_to parent.label, solr_document_path(parent.global_id) %></span>
       <% end %>
     <% end %>
   </ol>
 
   <%= content_tag :h1, class: "breadcrumb-item breadcrumb-item-#{parents.length + 4} media" do %>
-    <span class="media-body" aria-hidden="true"><%= blacklight_icon document_or_parent_icon(document) %></span>
+    <span class="media-body" aria-hidden="true"><%= blacklight_icon "arrow-return-right" %></span>
     <span class="col"><%= document.normalized_title %></span>
   <% end %>
 </nav>


### PR DESCRIPTION
# Summary 

- Remove the icons (except for the + - expand/collapse icons) from the Contents tab
- For Breadcrumbs - Campus and Repository icons to remain. The icons for all remaining levels should be something simple, like bullet points decreasing in size

# Related Issue
https://bugs.dlib.indiana.edu/browse/AR-69

# Screenshots / Video
![collection-context-icons](https://user-images.githubusercontent.com/18175797/111692948-43d58e00-87ed-11eb-9e49-7c4bb3dc7550.png)

# Deployment

To be deployed to Notch8 staging for demo

