### PR TITLE
upgrade solr wrapper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'arclight'
 gem 'blacklight_range_limit', '~> 7.1'
 group :development, :test do
-  gem 'solr_wrapper', '3.1.1'
+  gem 'solr_wrapper', '3.1.2'
   gem 'nulldb'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,7 +361,7 @@ GEM
       rack-protection (= 2.1.0)
       tilt (~> 2.0)
     slop (4.8.2)
-    solr_wrapper (3.1.1)
+    solr_wrapper (3.1.2)
       http
       retriable
       ruby-progressbar
@@ -484,7 +484,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   shoulda-matchers
   simplecov
-  solr_wrapper (= 3.1.1)
+  solr_wrapper (= 3.1.2)
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3


### PR DESCRIPTION
# Summary 
Upgrades solr_wrapper gem to version 3.1.2 to accommodate the move of solr's repository.

# Related Issue
[Solr moves to new address](https://solr.apache.org/news.html)
[solr_wrapper changes solr url](https://github.com/cbeer/solr_wrapper/commit/eba7951feb6fe651f6dff29c5509af62c41a1e6e)

# Fixes 
![image](https://user-images.githubusercontent.com/18175797/114077813-0ba9f400-985d-11eb-9e03-697b4daf53a7.png)
