### PR TITLE
AR-71 remove collection acqinfo from child components

### DIFF
--- a/lib/ngao-arclight/traject/ead2_config.rb
+++ b/lib/ngao-arclight/traject/ead2_config.rb
@@ -542,8 +542,6 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
     accumulator.concat(context.output_hash.fetch('access_subjects_ssim', []))
   end
 
-  to_field 'acqinfo_ssim', extract_xpath('/ead/archdesc/acqinfo/*[local-name()!="head"]')
-  to_field 'acqinfo_ssim', extract_xpath('/ead/archdesc/descgrp/acqinfo/*[local-name()!="head"]')
   to_field 'acqinfo_ssim', extract_xpath('./acqinfo/*[local-name()!="head"]')
   to_field 'acqinfo_ssim', extract_xpath('./descgrp/acqinfo/*[local-name()!="head"]')
 

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -60,5 +60,11 @@ RSpec.describe 'EAD 2 traject indexing', type: :feature do
     it 'indexes extents contained within a single physdesc as one string' do
       expect(result['extent_ssm']).to eq ['184 items ((1 box))', '8.15 cubic feet (One full-size records case, one letter-size documents case, twenty-six shelved books, and oversize material in flat storage.)']
     end
+
+    it 'collection acqinfo does not show on child elements' do
+      expect(result['acqinfo_ssim']).to eq ['Purchase:  1982']
+      component = result['components'].find { |c| c['id'] == ['InU-Li-VAD6017aspace_VAD6017-00001'] }
+      expect(component['acqinfo_ssim']).to eq ['Child acqinfo']
+    end
   end
 end

--- a/spec/fixtures/ead/lilly/VAD6017.xml
+++ b/spec/fixtures/ead/lilly/VAD6017.xml
@@ -177,6 +177,12 @@
           <physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">184
               items</extent><extent altrender="carrier">(1 box)</extent></physdesc>
         </did>
+        <descgrp>
+          <acqinfo id="aspace_b6a2bbe27ee03701a27909d6c7bf0f0e">
+            <head>Acquisition Information</head>
+            <p>Child acqinfo</p>
+          </acqinfo>
+        </descgrp>
       </c01>
     </dsc>
   </archdesc>


### PR DESCRIPTION

# Summary 
Acqinfo from collection level is displaying on all component levels. Acqinfo should only be shown if part of component information.

# Related Issue
https://bugs.dlib.indiana.edu/browse/AR-71

# Expected Behavior
Acqinfo should only show on a component if it is part of the component information

# Screenshots / Video
**Before:**
<img width="455" alt="Screen Shot 2021-04-09 at 8 06 48 AM" src="https://user-images.githubusercontent.com/18175797/114201452-0d31f580-990b-11eb-9dad-ca21d3272048.png">

**After:**
<img width="428" alt="Screen Shot 2021-04-09 at 8 07 17 AM" src="https://user-images.githubusercontent.com/18175797/114201456-0e632280-990b-11eb-9456-e0a6405fa0ee.png">


