### PR TITLE
Changes Scopecontent data type to allow indexing of larger notes

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -116,7 +116,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'normalized_date_ssm', label: 'Date'
     config.add_index_field 'creator_ssm', label: 'Creator'
     config.add_index_field 'language_ssm', label: 'Language'
-    config.add_index_field 'scopecontent_ssm', label: 'Scope Content', helper_method: :render_html_tags
+    config.add_index_field 'scopecontent_tesim', label: 'Scope Content', helper_method: :render_html_tags
     config.add_index_field 'extent_ssm', label: 'Physical Description'
     config.add_index_field 'accessrestrict_ssm', label: 'Conditions Governing Access', helper_method: :render_html_tags
     config.add_index_field 'collection_ssm', label: 'Collection Title'
@@ -275,7 +275,7 @@ class CatalogController < ApplicationController
     config.add_summary_field 'prefercite_ssm', label: 'Preferred citation', helper_method: :render_html_tags
 
     # Collection Show Page - Background Section
-    config.add_background_field 'scopecontent_ssm', label: 'Scope and Content', helper_method: :render_html_tags
+    config.add_background_field 'scopecontent_tesim', label: 'Scope and Content', helper_method: :render_html_tags
     config.add_background_field 'bioghist_ssm', label: 'Biographical / Historical', helper_method: :render_html_tags
     config.add_background_field 'acqinfo_ssim', label: 'Acquisition information', helper_method: :render_html_tags
     config.add_background_field 'appraisal_ssm', label: 'Appraisal information', helper_method: :render_html_tags
@@ -327,7 +327,7 @@ class CatalogController < ApplicationController
     }
     config.add_component_field 'abstract_ssm', label: 'Abstract', helper_method: :render_html_tags
     config.add_component_field 'extent_ssm', label: 'Extent'
-    config.add_component_field 'scopecontent_ssm', label: 'Scope and Content', helper_method: :render_html_tags
+    config.add_component_field 'scopecontent_tesim', label: 'Scope and Content', helper_method: :render_html_tags
     config.add_component_field 'acqinfo_ssim', label: 'Acquisition information', helper_method: :render_html_tags
     config.add_component_field 'language_ssm', label: 'Language', helper_method: :render_html_tags
     config.add_component_field 'appraisal_ssm', label: 'Appraisal information', helper_method: :render_html_tags

--- a/lib/ngao-arclight/traject/ead2_config.rb
+++ b/lib/ngao-arclight/traject/ead2_config.rb
@@ -246,12 +246,14 @@ end
 
 SEARCHABLE_NOTES_FIELDS.map do |selector|
   to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']", to_text: false)
+  to_field "scopecontent_tesim", extract_xpath("/ead/archdesc/scopecontent/*[local-name()!='head']", to_text: false)
   to_field "#{selector}_heading_ssm", extract_xpath("/ead/archdesc/#{selector}/head") unless selector == 'prefercite'
   to_field "#{selector}_teim", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']")
 end
 
 DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
   to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/did/#{selector}", to_text: false)
+  to_field "scopecontent_tesim", extract_xpath("/ead/archdesc/did/scopecontent", to_text: false)
 end
 
 NAME_ELEMENTS.map do |selector|
@@ -560,11 +562,13 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
 
   SEARCHABLE_NOTES_FIELDS.map do |selector|
     to_field "#{selector}_ssm", extract_xpath("./#{selector}/*[local-name()!='head']", to_text: false)
+    to_field "scopecontent_tesim", extract_xpath("./scopecontent/*[local-name()!='head']", to_text: false)
     to_field "#{selector}_heading_ssm", extract_xpath("./#{selector}/head")
     to_field "#{selector}_teim", extract_xpath("./#{selector}/*[local-name()!='head']")
   end
   DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
     to_field "#{selector}_ssm", extract_xpath("./did/#{selector}", to_text: false)
+    to_field "scopecontent_tesim", extract_xpath("./did/scopecontent", to_text: false)
   end
   to_field 'did_note_ssm', extract_xpath('./did/note')
 end

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -6,9 +6,7 @@
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
-
      http://www.apache.org/licenses/LICENSE-2.0
-
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -56,9 +54,7 @@
   </admin>
 
   <!-- SearchHandler
-
        http://wiki.apache.org/solr/SearchHandler
-
        For processing Search Queries, the primary Request Handler
        provided with Solr is "SearchHandler" It delegates to a sequent
        of SearchComponents (see below) and supports distributed
@@ -153,7 +149,7 @@
          language_ssm,
          level_ssm,
          repository_ssm,
-         scopecontent_ssm,
+         scopecontent_tesim,
          title_ssm,
          normalized_title_ssm,
          normalized_date_ssm,
@@ -165,7 +161,7 @@
          component_level_isim,
          parent_access_restrict_ssm,
          parent_access_terms_ssm,
-         names_coll_ssim
+         names_coll_ssim,
          places_ssim
        </str>
 
@@ -203,10 +199,8 @@
   </requestHandler>
 
 <!-- Spell Check
-
         The spell check component can return a list of alternative spelling
         suggestions.
-
         http://wiki.apache.org/solr/SpellCheckComponent
      -->
   <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
@@ -261,7 +255,6 @@
      -->
 
     <!-- a spellchecker that use an alternate comparator
-
          comparatorClass be one of:
           1. score (default)
           2. freq (Frequency first, then score)


### PR DESCRIPTION
Fixes issue of large scopecontent notes causing finding aids to fail to index

# Summary 
Arclight is packaged with most of the note fields indexing as the 'string' data type, which has a byte limit that some scopecontent notes were exceeding. This changes the indexing of scopecontent to the 'text' data type. This should allow the successful indexing of all finding aids.

# Related Issue
None

# Expected Behavior
All finding aids will successfully index into AO
