### PR TITLE
Improve management of the suggest search field

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ REPOSITORY_ID=paleontology DIR=./data/paleontology rake arclight:index_dir
 ```
 Open a browser and verify the application and indexed EAD files at http://localhost:3000/collections
 
+## Build suggest field
+Building the suggest list for searching, typeahead, is not done on indexing.  Building the suggest list is done with either the rake task or curl command below.  This should be run after indexing sample data.  Note: update solr url if not running the curl command in local development.
+
+```
+rake build_solr_suggest
+
+curl http://127.0.0.1:8983/solr/blacklight-core/suggest\?suggest.build\=true
+```
 ## Updating the application
 
 See https://github.com/sul-dlss/arclight/wiki/Upgrading-your-ArcLight-application

--- a/app/jobs/build_suggest_job.rb
+++ b/app/jobs/build_suggest_job.rb
@@ -6,11 +6,14 @@ class BuildSuggestJob
 
   def self.build_suggest_field
     # Not using Blacklight.default_index.connection for greater control
-    uri = URI("#{ENV['SOLR_URL']}/suggest?suggest.build=true")
+    uri = URI("#{ENV['SOLR_URL']}/suggest")
 
     ::Net::HTTP.start(uri.host, uri.port) do |http|
       http.read_timeout = 600
-      res = http.request_get(uri.path, 'Accept' => 'application/json')
+      params = "?suggest.build=true"
+      full_path = uri.path + params
+      puts "Building suggester field with #{uri}#{params}"
+      res = http.request_get(full_path, 'Accept' => 'application/json')
       res.value # raises exception if not 2XX status
       puts res.body
     end

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -295,7 +295,8 @@
       <str name="indexPath">suggester_infix_dir</str>
       <str name="highlight">false</str>
       <str name="suggestAnalyzerFieldType">text</str>
-      <str name="buildOnOptimize">true</str>
+      <str name="buildOnOptimize">false</str>
+      <str name="buildOnCommit">false</str>
       <str name="field">suggest</str>
     </lst>
   </searchComponent>


### PR DESCRIPTION
The incremental build of the auto-complete suggest field was previously disabled with #89 by setting `buildOnOptimize=true` in the Solr configuration.  This seemed to have the effect of implying 'buildOnCommit=false`, but this recently stopped working due to Solr version changes or some other nondeterministic change.  This PR makes it more intentional by setting both of the aforementioned settings to false, thereby requiring a manual build of the field, out-of-band from normal indexing. This is necessary with a large number of documents because the time to build the field with each commit becomes exponential. 

It also fixes a job that can be used to build the suggest field on demand via a rake task.  It does this via a call to the Solr 'suggest' endpoint. It was unknowingly not working due to mishandling of the parameters needed to trigger the build. 

**So NOTE**: if you pull and use this Solr configuration, the suggest auto-complete in the search box will not work without manually building the field with one of the following:

`rake build_solr_suggest`
`curl http://your.solr.server/solr/blacklight-core/suggest?suggest.build=true`