### PR TITLE
Changes Scopecontent data type to allow indexing of larger notes

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -116,7 +116,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'normalized_date_ssm', label: 'Date'
     config.add_index_field 'creator_ssm', label: 'Creator'
     config.add_index_field 'language_ssm', label: 'Language'
-    config.add_index_field 'scopecontent_ssm', label: 'Scope Content', helper_method: :render_html_tags
+    config.add_index_field 'scopecontent_tesim', label: 'Scope Content', helper_method: :render_html_tags
     config.add_index_field 'extent_ssm', label: 'Physical Description'
     config.add_index_field 'accessrestrict_ssm', label: 'Conditions Governing Access', helper_method: :render_html_tags
     config.add_index_field 'collection_ssm', label: 'Collection Title'
@@ -275,7 +275,7 @@ class CatalogController < ApplicationController
     config.add_summary_field 'prefercite_ssm', label: 'Preferred citation', helper_method: :render_html_tags
 
     # Collection Show Page - Background Section
-    config.add_background_field 'scopecontent_ssm', label: 'Scope and Content', helper_method: :render_html_tags
+    config.add_background_field 'scopecontent_tesim', label: 'Scope and Content', helper_method: :render_html_tags
     config.add_background_field 'bioghist_ssm', label: 'Biographical / Historical', helper_method: :render_html_tags
     config.add_background_field 'acqinfo_ssim', label: 'Acquisition information', helper_method: :render_html_tags
     config.add_background_field 'appraisal_ssm', label: 'Appraisal information', helper_method: :render_html_tags
@@ -334,7 +334,7 @@ class CatalogController < ApplicationController
     }
     config.add_component_field 'abstract_ssm', label: 'Abstract', helper_method: :render_html_tags
     config.add_component_field 'extent_ssm', label: 'Extent'
-    config.add_component_field 'scopecontent_ssm', label: 'Scope and Content', helper_method: :render_html_tags
+    config.add_component_field 'scopecontent_tesim', label: 'Scope and Content', helper_method: :render_html_tags
     config.add_component_field 'acqinfo_ssim', label: 'Acquisition information', helper_method: :render_html_tags
     config.add_component_field 'language_ssm', label: 'Language', helper_method: :render_html_tags
     config.add_component_field 'appraisal_ssm', label: 'Appraisal information', helper_method: :render_html_tags

--- a/lib/ngao-arclight/traject/ead2_config.rb
+++ b/lib/ngao-arclight/traject/ead2_config.rb
@@ -278,12 +278,14 @@ end
 
 SEARCHABLE_NOTES_FIELDS.map do |selector|
   to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']", to_text: false)
+  to_field "scopecontent_tesim", extract_xpath("/ead/archdesc/scopecontent/*[local-name()!='head']", to_text: false)
   to_field "#{selector}_heading_ssm", extract_xpath("/ead/archdesc/#{selector}/head") unless selector == 'prefercite'
   to_field "#{selector}_teim", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']")
 end
 
 DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
   to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/did/#{selector}", to_text: false)
+  to_field "scopecontent_tesim", extract_xpath("/ead/archdesc/did/scopecontent", to_text: false)
 end
 
 NAME_ELEMENTS.map do |selector|
@@ -461,7 +463,7 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
       physdesc = []
       element.children.map do |child|
         next if child.class == Nokogiri::XML::Element
-  
+
         physdesc << child.text&.strip unless child.text&.strip.empty?
       end.flatten
       physdesc.join(' ') unless physdesc.empty?
@@ -473,7 +475,7 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
       physdesc = []
       element.children.map do |child|
         next if child.class == Nokogiri::XML::Element
-  
+
         physdesc << child.text&.strip unless child.text&.strip.empty?
       end.flatten
       physdesc.join(' ') unless physdesc.empty?
@@ -622,11 +624,13 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
 
   SEARCHABLE_NOTES_FIELDS.map do |selector|
     to_field "#{selector}_ssm", extract_xpath("./#{selector}/*[local-name()!='head']", to_text: false)
+    to_field "scopecontent_tesim", extract_xpath("./scopecontent/*[local-name()!='head']", to_text: false)
     to_field "#{selector}_heading_ssm", extract_xpath("./#{selector}/head")
     to_field "#{selector}_teim", extract_xpath("./#{selector}/*[local-name()!='head']")
   end
   DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
     to_field "#{selector}_ssm", extract_xpath("./did/#{selector}", to_text: false)
+    to_field "scopecontent_tesim", extract_xpath("./did/scopecontent", to_text: false)
   end
   to_field 'did_note_ssm', extract_xpath('./did/note')
 end

--- a/lib/ngao-arclight/traject/ead2_config.rb
+++ b/lib/ngao-arclight/traject/ead2_config.rb
@@ -277,15 +277,17 @@ to_field 'date_range_sim', extract_xpath('/ead/archdesc/did/unitdate/@normal', t
 end
 
 SEARCHABLE_NOTES_FIELDS.map do |selector|
-  to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']", to_text: false)
-  to_field "scopecontent_tesim", extract_xpath("/ead/archdesc/scopecontent/*[local-name()!='head']", to_text: false)
+  if "#{selector}" == "scopecontent" then
+    to_field "#{selector}_tesim", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']", to_text: false)
+  else
+    to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']", to_text: false)
+  end
   to_field "#{selector}_heading_ssm", extract_xpath("/ead/archdesc/#{selector}/head") unless selector == 'prefercite'
   to_field "#{selector}_teim", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']")
 end
 
 DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
   to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/did/#{selector}", to_text: false)
-  to_field "scopecontent_tesim", extract_xpath("/ead/archdesc/did/scopecontent", to_text: false)
 end
 
 NAME_ELEMENTS.map do |selector|
@@ -623,14 +625,16 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
   end
 
   SEARCHABLE_NOTES_FIELDS.map do |selector|
-    to_field "#{selector}_ssm", extract_xpath("./#{selector}/*[local-name()!='head']", to_text: false)
-    to_field "scopecontent_tesim", extract_xpath("./scopecontent/*[local-name()!='head']", to_text: false)
+    if "#{selector}" == "scopecontent" then
+      to_field "#{selector}_tesim", extract_xpath("./#{selector}/*[local-name()!='head']", to_text: false)
+    else
+      to_field "#{selector}_ssm", extract_xpath("./#{selector}/*[local-name()!='head']", to_text: false)
+    end
     to_field "#{selector}_heading_ssm", extract_xpath("./#{selector}/head")
     to_field "#{selector}_teim", extract_xpath("./#{selector}/*[local-name()!='head']")
   end
   DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
     to_field "#{selector}_ssm", extract_xpath("./did/#{selector}", to_text: false)
-    to_field "scopecontent_tesim", extract_xpath("./did/scopecontent", to_text: false)
   end
   to_field 'did_note_ssm', extract_xpath('./did/note')
 end

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -153,7 +153,7 @@
          language_ssm,
          level_ssm,
          repository_ssm,
-         scopecontent_ssm,
+         scopecontent_tesim,
          title_ssm,
          normalized_title_ssm,
          normalized_date_ssm,


### PR DESCRIPTION
Fixes issue of large scopecontent notes causing finding aids to fail to index

# Summary 
Arclight is packaged with most of the note fields indexing as the 'string' data type, which has a byte limit that some scopecontent notes were exceeding. This changes the indexing of scopecontent to the 'text' data type. This allows the successful indexing of all finding aids.

# Related Issue
None

# Expected Behavior
All finding aids should successfully index into Arclight
