### PR TITLE
Adds delete single ead

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'webdrivers'
   gem 'shoulda-matchers'
+  gem 'database_cleaner-active_record'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,10 @@ GEM
     crass (1.0.6)
     daemons (1.3.1)
     database_cleaner (1.8.5)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     delayed_job (4.1.8)
       activesupport (>= 3.0, < 6.1)
     delayed_job_active_record (4.1.4)
@@ -458,6 +462,7 @@ DEPENDENCIES
   coveralls
   daemons
   database_cleaner
+  database_cleaner-active_record
   delayed_job_active_record
   delayed_job_web
   devise

--- a/README.md
+++ b/README.md
@@ -6,13 +6,19 @@ To setup the server:
 
 ```
 bundle install
-bundle exec rake db:migrate
 ```
 
 Then, in a separate console, run the Rails and Solr servers:
 
 ```
 bundle exec rake demo:server  # runs both Rails and Solr
+```
+
+Note: Only run the three commands below only if it is the first time spinning up the app locally.
+```
+bundle exec rake db:migrate
+bundle exec rake assets:precompile
+bundle exec rake db:test:prepare
 ```
 
 ## Indexing sample data
@@ -31,6 +37,20 @@ rake build_solr_suggest
 
 curl http://127.0.0.1:8983/solr/blacklight-core/suggest\?suggest.build\=true
 ```
+
+## Running tests
+
+To run tests use:
+```
+bundle exec rspec
+```
+
+There are a few very slow tests that involve the OmniAuth controller.  These have been excluded by default.  To run these tests specifically use:
+```
+bundle exec rspec --tag omni spec/
+```
+Edit `./.rspec` to change which tests are excluded by default.
+
 ## Updating the application
 
 See https://github.com/sul-dlss/arclight/wiki/Upgrading-your-ArcLight-application

--- a/app/assets/stylesheets/iu-branding.scss
+++ b/app/assets/stylesheets/iu-branding.scss
@@ -158,3 +158,20 @@ li.al-collection-context .al-online-content-icon svg,
   background-color: $iu-white;
   color: $iu-grey;
 }
+
+// Collapse +/- indicators on admin delete dropdown
+.toggle-delete {
+  color: black;
+  &::before {
+    content: image-url('blacklight/plus.svg');
+    float: right;
+  }
+  &:not(.collapsed)::before {
+    content: image-url('blacklight/minus.svg');
+    float: right;
+  }
+}
+
+.toggle-delete:hover {
+  text-decoration: none;
+}

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -6,6 +6,7 @@ class AdminController < ApplicationController
     EadProcessor.get_updated_eads
     @users = User.all
     @repositories = current_user.admin? ? Repository.all : current_user.repositories
+    @delta_eads = EadProcessor.get_delta_eads
   end
 
   def index_eads
@@ -25,6 +26,14 @@ class AdminController < ApplicationController
     args = { ead: file, repository: repository }
     EadProcessor.delay.index_single_ead(args)
     redirect_to admin_path, notice: 'The file is being indexed in the background and will be ready soon.'
+  end
+
+  def delete_ead
+    # Ead format - VAD5800.xml
+    file = params[:ead]
+    args = { ead: file}
+    EadProcessor.delete_single_ead(args)
+    redirect_to admin_path, notice: 'The file is being deleted in the background and will be removed soon.'
   end
 
   def delete_user

--- a/app/models/ead_processor.rb
+++ b/app/models/ead_processor.rb
@@ -87,6 +87,13 @@ class EadProcessor
     EadProcessor.delay.index_file(fpath, repository)
   end
 
+  # for deleting a single ead file
+  def self.delete_single_ead(args = {})
+    filename = args[:ead]
+    ENV['FILE'] = filename
+    `bundle exec rake ngao:delete_ead`
+  end
+
   # extract file
   def self.extract_file(file, directory)
     Zip::File.open(file) do |zip_file|
@@ -157,10 +164,32 @@ class EadProcessor
     return eads
   end
 
+  # get list of eads in solr and postgres but no longer on archive space
+  def self.get_delta_eads(args = {})
+    delta_eads = []
+    archive_space_eads = []
+    for ead in page(args).css('a')
+      name = ead.attributes['href'].value
+      ext = File.extname(name)
+      name = File.basename(name, File.extname(name))
+      next unless ext == '.xml'
+
+      ead_filename = name + ext
+      archive_space_eads << ead_filename
+    end
+    local_eads = Ead.all.collect.each { |e| e.filename }
+    delta_eads = local_eads - archive_space_eads
+    delta_eads.uniq.sort
+  end
+
   def self.add_ead_to_db(filename, repository_id)
     Ead.where(filename: filename).first_or_create do |ead|
       ead.repository = Repository.find_by(repository_id: repository_id)
     end
+  end
+
+  def self.remove_ead_from_db(filename)
+    Ead.find_by(filename: filename)&.destroy
   end
 
   def self.add_last_indexed(filename, indexed_at)

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -18,6 +18,38 @@
             <div class="row col">
               <%= link_to "Index all EADs for all repositories", index_eads_url, class: "btn btn-lg btn-primary mt-4 mb-4" %>
             </div>
+            <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+              <div class="panel panel-default">
+                  <div class="panel-heading" role="tab" id="headingOne">
+                      <h4 class="panel-title">
+                          <a role="button" class="toggle-delete collapsed" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+                              Delete EAD
+                          </a>
+                      </h4>
+                  </div>
+                  <div id="collapseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+                    <div class="panel-body">
+                      <p>EADs that are no longer present on ArchiveSpace but have not yet been purged from Archives Online.</p>
+                      <table class="table">
+                        <thead>
+                          <tr>
+                            <th>Ead</th>
+                            <th class="text-right">Action</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <% @delta_eads.each do |d| %>
+                            <tr>
+                              <td><%= d %></td>                       
+                              <td class="text-right"><%= link_to "Delete", delete_ead_url(ead: d), class: 'btn btn-sm btn-primary', data: { confirm: "Are you sure?" } %></td>
+                            </tr>
+                          <% end %>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+              </div>
+            </div>
           <% end %>
         
           <div class="row mb-1">
@@ -39,7 +71,7 @@
                       <th>Eads in this Repository</th>
                       <th>Last Update</th>
                       <th>Last Index</th>
-                      <th></th>
+                      <th>Actions</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -52,6 +84,7 @@
                         <td><%= ead.last_indexed_at&.strftime("%m/%d/%Y at %I:%M%p") %></td>
                         <td>
                           <%= link_to "Index", index_ead_url(repository: repo.repository_id, ead: ead.filename), class: 'btn btn-sm btn-primary' %>
+                          <%= link_to "Delete", delete_ead_url(ead: ead.filename), class: 'btn btn-sm btn-primary', data: { confirm: "Are you sure?" } %>
                         </td>
                       </tr>
                     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
   get 'admin/index_eads', to: 'admin#index_eads', as: 'index_eads'
   get 'admin/index_repository', to: 'admin#index_repository', as: 'index_repository'
   get 'admin/index_ead', to: 'admin#index_ead', as: 'index_ead'
+  get 'admin/delete_ead', to: 'admin#delete_ead', as: 'delete_ead'
   delete 'admin/delete_user/:id', to: 'admin#delete_user', as: 'admin_delete_user'
   get 'admin/update_user_role/:id', to: 'admin#update_user_role', as: 'admin_update_user_role'
   get 'admin/edit_repository/:id', to: 'admin#edit_repository', as: 'admin_edit_repository'

--- a/lib/tasks/delete_ead.rake
+++ b/lib/tasks/delete_ead.rake
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+namespace :ngao do
+  desc 'Clear single EAD from Solr'
+  task delete_ead: :environment do
+    raise 'Please specify your EAD document, ex. ead.xml' unless ENV['FILE']
+
+    filename = ENV['FILE']
+    solr_id = filename.tr('.xml','')
+
+    print "NGAO-Arclight deleting #{ENV['FILE']}...\n"
+
+    if Rails.env == 'development'
+      solr_url = 'http://localhost:8983/solr/blacklight-core'
+    else
+      solr_url = begin
+                  Blacklight.default_index.connection.base_uri.to_s
+                rescue StandardError
+                  ENV['SOLR_URL'] || 'http://localhost:8983/solr/blacklight-core'
+                end
+    end
+    # one slash per segment only please
+    solr_url.chomp!('/')
+
+    solr_elapsed_time = Benchmark.realtime do
+      cmd = %Q{curl -X POST "#{solr_url}/update?commit=true" -H "Content-Type: text/xml" --data-binary "<delete><id>#{solr_id}</id></delete>"}
+      puts cmd
+      `#{cmd}`
+    end
+
+    print "NGAO-Arclight deleted #{filename} from solr index (in #{solr_elapsed_time.round(3)} secs).\n"
+
+    postgres_elapsed_time = Benchmark.realtime do
+      EadProcessor.remove_ead_from_db(filename)
+    end
+
+    print "NGAO-Arclight deleted #{filename} from postgres database (in #{postgres_elapsed_time.round(3)} secs).\n"
+  end
+end

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AdminController, type: :controller, omni: true do
+  include Devise::Test::ControllerHelpers
+
+  let(:admin_user) { FactoryBot.create(:user, role = 'admin') }
+  let(:manager_user) { FactoryBot.create(:user, role = 'manager') }
+  
+  before do
+    request.env['devise.mapping'] = Devise.mappings[:user]
+    request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:cas]
+    ENV['ASPACE_EXPORT_URL'] = 'https://aspacedev.dlib.indiana.edu/assets/ead_export/'
+  end
+
+  OmniAuth.config.mock_auth[:cas] =
+    OmniAuth::AuthHash.new(
+      provider: 'cas',
+      uid: 'jim_watson'
+    )
+
+  after do
+    ENV['ASPACE_EXPORT_URL'] = 'http://localhost/assets/ead_export/'
+  end
+
+  context 'when user is unathenticated' do
+    describe 'GET #index' do
+      it 'redirects to sign-in page' do
+        get :index
+        expect(response).to be_redirect
+        expect(response.redirect_url).to eq('http://test.host/users/auth/cas')
+      end
+    end
+  end
+
+  context 'when logged in as a manager user' do
+    before do
+      # Switch to Omniauth Controller for CAS authentication
+      old_controller = @controller
+      @controller = Users::OmniauthCallbacksController.new
+      post :cas
+      login_as manager_user
+      @controller = old_controller
+    end
+
+    describe 'GET #index' do
+      it 'redirects to dashboard' do
+        expect(response.redirect_url).to eq 'http://test.host/admin'
+      end
+
+      it 'returns a success response' do
+        valid_session = {}
+        get :index, params: {}, session: valid_session
+        expect(response).to be_successful
+      end
+
+      it 'indexes the users and repository' do
+        get :index
+        expect(assigns(:users)).to eq(User.all)
+        expect(assigns(:repositories)).to eq(manager_user.repositories)
+      end
+    end
+
+    describe 'GET #index_repositories' do
+      it 'redirects to dashboard' do
+        get :index_repository, params: { repository: 'lilly' }
+        expect(response.redirect_url).to eq 'http://test.host/admin'
+        expect(flash[:notice]).to eq 'These files are being indexed in the background and will be ready soon.'
+      end
+    end
+
+    describe 'GET #index_ead' do
+      it 'redirects to dashboard' do
+        get :index_ead, params: { repository: 'lilly', ead: 'VAD6017.xml' }
+        expect(response.redirect_url).to eq 'http://test.host/admin'
+        expect(flash[:notice]).to eq 'The file is being indexed in the background and will be ready soon.'
+      end
+    end
+
+    describe 'GET #delete_ead' do
+      it 'redirects to dashboard' do
+        get :delete_ead, params: { ead: 'VAD6017.xml' }
+        expect(response.redirect_url).to eq 'http://test.host/admin'
+        expect(flash[:notice]).to eq 'The file is being deleted in the background and will be removed soon.'
+      end
+    end
+  end
+
+  context 'when logged in as an admin user' do
+    before do
+      # Switch to Omniauth Controller for CAS authentication
+      old_controller = @controller
+      @controller = Users::OmniauthCallbacksController.new
+      post :cas
+      login_as admin_user
+      @controller = old_controller
+    end
+
+    describe 'GET #index' do
+      it 'redirects to dashboard' do
+        expect(response.redirect_url).to eq 'http://test.host/admin'
+      end
+
+      it 'returns a success response' do
+        valid_session = {}
+        get :index, params: {}, session: valid_session
+        expect(response).to be_successful
+      end
+
+      it 'indexes the users and repository' do
+        get :index
+        expect(assigns(:users)).to eq(User.all)
+        expect(assigns(:repositories)).to eq(admin_user.repositories)
+      end
+    end
+
+    describe 'GET #index_repositories' do
+      it 'redirects to dashboard' do
+        get :index_repository, params: { repository: 'lilly' }
+        expect(response.redirect_url).to eq 'http://test.host/admin'
+        expect(flash[:notice]).to eq 'These files are being indexed in the background and will be ready soon.'
+      end
+    end
+
+    describe 'GET #index_ead' do
+      it 'redirects to dashboard' do
+        get :index_ead, params: { repository: 'lilly', ead: 'VAD6017.xml' }
+        expect(response.redirect_url).to eq 'http://test.host/admin'
+        expect(flash[:notice]).to eq 'The file is being indexed in the background and will be ready soon.'
+      end
+    end
+
+    describe 'GET #delete_ead' do
+      it 'redirects to dashboard' do
+        get :delete_ead, params: { ead: 'VAD6017.xml' }
+        expect(response.redirect_url).to eq 'http://test.host/admin'
+        expect(flash[:notice]).to eq 'The file is being deleted in the background and will be removed soon.'
+      end
+    end
+  end
+end

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Users::OmniauthCallbacksController, type: :controller, omni: true do
+  include Devise::Test::ControllerHelpers
+
+  before do
+    User.create(provider: 'cas',
+                uid: 'jim_watson')
+    request.env['devise.mapping'] = Devise.mappings[:user]
+    request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:cas]
+  end
+  OmniAuth.config.mock_auth[:cas] =
+    OmniAuth::AuthHash.new(
+      provider: 'cas',
+      uid: 'jim_watson'
+    )
+
+  # If a user logs in it will redirect to admin page
+  context 'with authenticated user' do
+    it 'redirects to origin' do
+      post :cas
+      expect(response.redirect_url).to eq 'http://test.host/admin'
+    end
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,16 @@
+
+# frozen_string_literal: true
+
+FactoryBot.define do
+  # User objects are created from data passed from CAS.
+  # The only field we get is uid. All user objects are given the
+  # provider "cas"
+  factory :user, class: User do
+    provider { "cas" }
+    sequence(:email) { |_n| "email-#{srand}@test.com" }
+    sequence :uid do |n|
+      "#{srand}#{n}"
+    end
+    password { "secret" }
+  end
+end

--- a/spec/models/ead_processor_spec.rb
+++ b/spec/models/ead_processor_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'pathname'
 
-RSpec.describe EadProcessor do
+RSpec.describe EadProcessor, clean: true do
   it 'gets the client without args' do
     client = EadProcessor.client
     expect(client).to eq 'http://localhost/assets/ead_export/'
@@ -60,9 +60,9 @@ RSpec.describe EadProcessor do
 
   context 'eads' do
     let(:repository) { Repository.new }
+    let(:filename) { 'VAD3254.xml' }
 
     it 'adds the ead to the db' do
-      filename = 'VAD3254.xml'
       repository.repository_id = 'mix'
       ead = EadProcessor.add_ead_to_db(filename, repository.repository_id)
       expect(ead.filename).to eq(filename)
@@ -70,7 +70,6 @@ RSpec.describe EadProcessor do
 
     it 'adds the ead last_updated_at' do
       repository.repository_id = 'mix'
-      filename = 'VAD3254.xml'
       ead = EadProcessor.add_ead_to_db(filename, repository.repository_id)
       last_updated_at = Time.now
       updated_ead = EadProcessor.add_last_updated(filename, last_updated_at)
@@ -79,11 +78,20 @@ RSpec.describe EadProcessor do
 
     it 'adds the ead last_indexed_at' do
       repository.repository_id = 'mix'
-      filename = 'VAD3254.xml'
       ead = EadProcessor.add_ead_to_db(filename, repository.repository_id)
       last_indexed_at = Time.now
       updated_ead = EadProcessor.add_last_updated(filename, last_indexed_at)
       expect(updated_ead).to be true
+    end
+
+    it 'removes a single ead' do
+      repository.repository_id = 'mix'
+      ead = EadProcessor.add_ead_to_db(filename, repository.repository_id)
+      r = repository.save
+      existing_repo = Repository.find(1)
+      expect(Ead.count).to eq 1
+      EadProcessor.remove_ead_from_db(filename)
+      expect(Ead.count).to eq 0
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+# This file is copied to spec/ when you run 'rails generate rspec:install'
+require 'spec_helper'
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path('../config/environment', __dir__)
+# Prevent database truncation if the environment is production
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require 'rspec/rails'
+# Add additional requires below this line. Rails is not loaded until this point!
+
+# Requires supporting ruby files with custom matchers and macros, etc, in
+# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
+# run as spec files by default. This means that files in spec/support that end
+# in _spec.rb will both be required and run as specs, causing the specs to be
+# run twice. It is recommended that you do not name files matching this glob to
+# end with _spec.rb. You can configure this pattern with the --pattern
+# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
+#
+# The following line is provided for convenience purposes. It has the downside
+# of increasing the boot-up time by auto-requiring all files in the support
+# directory. Alternatively, in the individual `*_spec.rb` files, manually
+# require only the support files necessary.
+
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+
+RSpec.configure do |config|
+  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
+  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+
+  # Assigned to false to allow use of factories
+  config.use_transactional_fixtures = false
+
+  config.before(:suite) do
+    if config.use_transactional_fixtures?
+      raise(<<-MSG)
+        Delete line `config.use_transactional_fixtures = true` from rails_helper.rb
+        (or set it to false) to prevent uncommitted transactions being used in
+        JavaScript-dependent specs.
+
+        During testing, the app-under-test that the browser driver connects to
+        uses a different database connection to the database connection used by
+        the spec. The app's database connection would not be able to access
+        uncommitted transaction data setup over the spec's database connection.
+      MSG
+    end
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, type: :feature) do
+    # :rack_test driver's Rack app under test shares database connection
+    # with the specs, so continue to use transaction strategy for speed.
+    driver_shares_db_connection_with_specs = Capybara.current_driver == :rack_test
+
+    unless driver_shares_db_connection_with_specs
+      # Driver is probably for an external browser with an app
+      # under test that does *not* share a database connection with the
+      # specs, so use truncation strategy.
+      DatabaseCleaner.strategy = :truncation
+    end
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.append_after(:each) do
+    DatabaseCleaner.clean
+  end
+  
+  config.before(clean: true) do
+    solr = Blacklight.default_index.connection
+    solr.delete_by_query '*:*'
+    solr.commit
+  end
+
+  config.include FactoryBot::Syntax::Methods
+  config.include Devise::Test::ControllerHelpers, type: :helper
+  config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Warden::Test::Helpers
+
+  # You can uncomment this line to turn off ActiveRecord support entirely.
+  # config.use_active_record = false
+
+  # RSpec Rails can automatically mix in different behaviours to your tests
+  # based on their file location, for example enabling you to call `get` and
+  # `post` in specs under `spec/controllers`.
+  #
+  # You can disable this behaviour by removing the line below, and instead
+  # explicitly tag your specs with their type, e.g.:
+  #
+  #     RSpec.describe UsersController, type: :controller do
+  #       # ...
+  #     end
+  #
+  # The different available types are documented in the features, such as in
+  # https://relishapp.com/rspec/rspec-rails/docs
+  config.infer_spec_type_from_file_location!
+
+  # Filter lines from Rails gems in backtraces.
+  config.filter_rails_from_backtrace!
+  # arbitrary gems may also be filtered via:
+  # config.filter_gems_from_backtrace("gem name")
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,10 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.before(:all) do
+    FactoryBot.reload
+  end
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
# Summary
Delete a single EAD from Solr and the local database.

Use case: User has deleted EAD from ArchiveSpace and would like to immediately remove it from the ArcLight site rather than wait for the weekly update job to complete.

# Related Ticket
[AR-106](https://bugs.dlib.indiana.edu/browse/AR-106)

# Expected Behavior
- [x] an admin user can use a select drop down to delete any records in Solr and the local database that was not present on the Archive Space EAD export site and may use button described below
- [x] a manager level user can delete a single EAD with a button (next to index button)
- [x] a developer can delete a single EAD from Solr and the local database with a rake task

# Video
<details>
https://gitlab.com/notch8/ngao/uploads/a76c51e3dfef686bb9b43cf69a6c4254/Screen_Recording_2021-04-28_at_03.53_PM.mov
</details>

# Screenshots
### Delete Process - Admin Index Page
<details> 

![image](https://user-images.githubusercontent.com/36549923/119726363-e3cf1980-be25-11eb-8cd8-9ee338e2ab14.png)

</details>