### PR TITLE
Revert to omniauth-cas gem for CAS under IU Login 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,5 +95,5 @@ gem 'mysql2'
 gem 'whenever', require: false
 gem 'delayed_job_active_record'
 gem "delayed_job_web"
-gem 'omniauth-iu-cas'
+gem 'omniauth-cas'
 gem 'daemons'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
     omniauth (1.9.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
-    omniauth-iu-cas (1.1.1.1)
+    omniauth-cas (2.0.0)
       addressable (~> 2.3)
       nokogiri (~> 1.5)
       omniauth (~> 1.2)
@@ -470,7 +470,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mysql2
   nulldb
-  omniauth-iu-cas
+  omniauth-cas
   pry
   puma (~> 3.12)
   rails (~> 5.2.5)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,4 +64,5 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { protocol: ENV['SITE_PROTOCOL'] || 'http',
                                                host: ENV['SITE_HOST'] || 'localhost:3000'}
+  config.force_ssl = true
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -310,12 +310,11 @@ Devise.setup do |config|
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
   config.omniauth :cas,
-                  :host => 'cas.iu.edu',
-                  :login_url => '/cas/login',
-                  :service_validate_url => '/cas/serviceValidate',
-                  :logout_url => '/cas/logout',
-                  :cassvc => 'ANY',
-                  :ssl => true
+                  host: ENV['CAS_HOST'] || 'idp-stg.login.iu.edu',
+                  login_url: ENV['CAS_LOGIN_URL'] || '/idp/profile/cas/login',
+                  service_validate_url: ENV['CAS_VALIDATE_URL'] || '/idp/profile/cas/serviceValidate',
+                  logout_url: ENV['CAS_LOGOUT_URL'] || '/idp/profile/cas/logout',
+                  ssl: true
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
Stop using the IU version of omniauth-cas with non-standard CAS interactions. Also allows full configuration of CAS parameters via environment variables. Incidentally sets config.force_ssl = true for the development environment; IU CAS requires the callback service to be secure, so even developer the stack must run Rails via SSL. Instructions for running Rails with SSL will be documented on Wiki pages, README, etc.