### PR TITLE
add origination (creator) to component page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -357,6 +357,7 @@ class CatalogController < ApplicationController
     config.add_component_field 'fileplan_ssm', label: 'File plan', helper_method: :render_html_tags
     config.add_component_field 'materialspec_ssm', label: 'Materials specific details', helper_method: :render_html_tags
     config.add_component_field 'physdesc_ssm', label: 'Physical description', helper_method: :render_html_tags
+    config.add_component_field 'creator_ssm', label: 'Creator', helper_method: :render_html_tags
 
     # Component Show Page - Indexed Terms Section
     config.add_component_indexed_terms_field 'access_subjects_ssim', label: 'Subjects', link_to_facet: true, separator_options: {


### PR DESCRIPTION

# Summary 
Adds origination field to Catalog Controller as "Creator" and `creator_ssm`


# Screenshots / Video
<img width="323" alt="Screen Shot 2021-06-02 at 9 43 08 AM" src="https://user-images.githubusercontent.com/18175797/120520865-2abe9100-c389-11eb-8627-43de20d4b8d5.png">


