### PR TITLE
AR-133 Ensuring EAD row is destroyed after running rake task to delete

### DIFF
--- a/app/models/ead_processor.rb
+++ b/app/models/ead_processor.rb
@@ -96,6 +96,9 @@ class EadProcessor
     filename = args[:ead]
     ENV['FILE'] = filename
     `bundle exec rake ngao:delete_ead`
+    # FIXME In production deployment, the row isn't being destroyed by the rake task
+    #  so try a direct invocation of the remove_ead_from_db method
+    remove_ead_from_db(filename)
   end
 
   # extract file


### PR DESCRIPTION
For some undetermined reason in the production deployment, deleting a EAD from the UI removes it from Solr but not the tracking database.  The result is that the file still appears in the admin page as still being indexed in the system when it is not.  However, the same rake task that is called from the controller action works as expected from the command line.

This PR adds one more call to remove the database entry after the rake task invocation is complete.  This shouldn't be necessary, but works until further investigation is possible.