### PR TITLE
Adding Harmful Language Statement to sub footer

### DIFF
--- a/app/views/shared/_user_auth_links.html.erb
+++ b/app/views/shared/_user_auth_links.html.erb
@@ -1,4 +1,5 @@
 <% if current_user %>
+  <li class="nav-item ml-3"><a class="nav-link" href="https://libraries.indiana.edu/harmful-language-statement">Harmful Language Statement</a></li>
   <li class="nav-item ml-3">
     <%= link_to "Admin", admin_path, class: 'nav-link' %>
   </li>
@@ -7,6 +8,7 @@
   </li>
   <li class="nav-item ml-3"><a class="nav-link" href="http://www.dlib.indiana.edu/collections/findingaids">Legacy Archives Online</a></li>
 <% else %>
+  <li class="nav-item ml-3"><a class="nav-link" href="https://libraries.indiana.edu/harmful-language-statement">Harmful Language Statement</a></li>
   <li class="nav-item ml-3">
     <%= link_to "Admin", admin_path, class: 'nav-link' %>
   </li>


### PR DESCRIPTION
# Summary 
Adds link to Harmful Language Statement (external site link) in sub footer before Admin/Logout links. 