### PR TITLE
Remove component ID punctuation change from Traject

### DIFF
--- a/lib/ngao-arclight/traject/ead2_config.rb
+++ b/lib/ngao-arclight/traject/ead2_config.rb
@@ -344,7 +344,7 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
                      record['id'] = hexdigest
                      hexdigest
                    else
-                     record.attribute('id')&.value&.strip&.gsub('.', '-')
+                     record.attribute('id')&.value&.strip
                    end
   end
   to_field 'ref_ssm' do |_record, accumulator, context|


### PR DESCRIPTION
Traject's default behavior substitutes '.' with '-' in the component ID. This causes issues with the proper indexing and display of the child components. Removing this functionality will hopefully allow everything to display and work as expected.

# Expected Behavior

Component IDs will be imported/indexed as originally entered in the EAD or ASpace.  For example, when looking at a specific component or performing a search, the 'parent_ssi' parameter should display "aspace_ATM-MC1.1" instead of "aspace_ATM-MC1-1".

# Side Effects

 It is unknown why subbing '.' with '-' was implemented into Traject in the first place. This update may potentially break other indexing, display functionalities, or cause other unforeseen issues.