### PR TITLE
Adding option to set openssl_verify_mode for email servers with self-…

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,11 +96,13 @@ Rails.application.configure do
     :user_name => ENV["SMTP_USERNAME"], #Your SMTP user
     :password => ENV["SMTP_PASSWORD"], #Your SMTP password
     :authentication => :login,
+    :openssl_verify_mode => ENV["SMTP_SSL_VERIFY"] || "none",
     :enable_starttls_auto => true
   }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+
   # config.action_mailer.raise_delivery_errors = false
   #
   config.action_mailer.default_url_options = { protocol: ENV['SITE_PROTOCOL'] || 'http',

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'info@notch8.cloud'
+  config.mailer_sender = ENV["SMTP_SENDER"] || 'info@example.cloud'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
When migrating to new servers, tweaks were required to the SMTP options to disable verification of self-signed email server certs.

Also changing the Devise sender configuration so that it can be set via an environment variable.