### PR TITLE
Fix fonts rendering in serif typeface after viewing printable EAD

### DIFF
--- a/app/views/catalog/_show_actions_box_default.html.erb
+++ b/app/views/catalog/_show_actions_box_default.html.erb
@@ -1,5 +1,6 @@
 <%# COPIED FROM ARCLIGHT TO REMOVE BOOKMARK CHECKBOX %>
-<div class='al-show-actions-box'>
+<%# disable turbolinks on download links to handle CSS stylesheets for printable EAD properly %>
+<div class='al-show-actions-box' data-turbolinks="false">
   <div class="al-actions-box-container">
     <% if document.unitid || document.containers.present? %>
       <div class='al-collection-id'>


### PR DESCRIPTION
Fixes https://bugs.dlib.indiana.edu/browse/AR-139

# Summary 
Fix fonts rendering in serif typeface after viewing printable EAD

# Details
Turbolinks was causing the CSS for printable EADs to remain loded
when returning to the previous page, thus rendering some fonts on the
catalog view pages to render in serif fonts.
    
Disablling turbo-links for the printable and xml EAD views causes
the pages to load with their own CSS, and prevents the print-only
settings from accidentaly being retained by turob-link loaded pages.


