### PR TITLE
Adds collection id to all levels of the archive.

### DIFF
--- a/app/views/catalog/_show_actions_box_default.html.erb
+++ b/app/views/catalog/_show_actions_box_default.html.erb
@@ -1,21 +1,18 @@
 <%# COPIED FROM ARCLIGHT TO REMOVE BOOKMARK CHECKBOX %>
 <%# disable turbolinks on download links to handle CSS stylesheets for printable EAD properly %>
-<div class='al-show-actions-box' data-turbolinks="false">
-  <div class="al-actions-box-container">
-    <% if document.unitid || document.containers.present? %>
-      <div class='al-collection-id'>
-        <% if document.unitid %>
-          <%= t(:'arclight.views.show.collection_id', id: document.unitid) %>
-        <% end %>
+  <div class='al-show-actions-box' data-turbolinks="false"> <div class="al-actions-box-container">
+    <% if document.collection_unitid || document.containers.present? %>
+      <div class='al-collection-id '>
 
-        <% if document.unitid && document.containers.present? %>
-          <span> | </span>
+        <% if document.collection_unitid %>
+          <strong class="text-nowrap"><%= t(:'arclight.views.show.collection_id', id: document.collection_unitid) %></strong>
         <% end %>
 
         <% if document.containers.present? %>
           <span><%= document.containers.join(', ') %></span>
         <% end %>
       </div>
+
     <% end %>
     <div class='al-show-actions-box-options d-flex'>
       <%= render partial: 'arclight/requests', locals: { document: document } %>


### PR DESCRIPTION
Fixes [#AR-111](https://bugs.dlib.indiana.edu/browse/AR-111)

# Summary 
Gray box displays collection level ID and Component Unique Identifier (when present) on all levels

# Screenshots / Video

### Series
![screencapture-localhost-3000-catalog-VAD5804aspace-VAD5804-00011-2022-06-06-13_28_54](https://user-images.githubusercontent.com/8102/172223425-3f7befa3-4c81-4a0a-a473-7489062862f6.png)

### Collection
![screencapture-localhost-3000-catalog-VAD5804-2022-06-06-13_31_00](https://user-images.githubusercontent.com/8102/172223703-d24be278-25dc-49f2-9c87-cc6bc8204ab5.png)

