### PR TITLE
Removes containers display in the arclight actions box

### DIFF
--- a/app/views/catalog/_show_actions_box_default.html.erb
+++ b/app/views/catalog/_show_actions_box_default.html.erb
@@ -8,9 +8,6 @@
           <strong class="text-nowrap"><%= t(:'arclight.views.show.collection_id', id: document.collection_unitid) %></strong>
         <% end %>
 
-        <% if document.containers.present? %>
-          <span><%= document.containers.join(', ') %></span>
-        <% end %>
       </div>
 
     <% end %>


### PR DESCRIPTION
Fixes [#AR-111](https://bugs.dlib.indiana.edu/browse/AR-111)

# Summary 
Removes containers displayed in the arclight actions box or the gray box display.

