### PR TITLE
Persist Solr binaries and data

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,6 +1,9 @@
 # Place any default configuration for solr_wrapper here
 version: 8.8.2
+solr_zip_path: tmp/solr_install
+instance_dir: tmp/solr_instance
 # port: 8983
 collection:
   dir: solr/conf/
   name: blacklight-core
+  persist: true


### PR DESCRIPTION
# Summary 
By default, solr_wrapper stores the downloaded solrxxx.zip install file and the Solr instance data directories under the `/var` directory.  Mac OSX clears the /var directory on every reboot, so, prior to these changes, you would loose any Solr data in your development environment and you'd have to re-download and install Solr after every reboot.

This change stores the installer and the instance data in the `tmp/` directory within the Rails project folder.

# Expected Behavior
Solr binaries and development instance data will persist after rebooting development machines
