### PR TITLE
Ignore files created by import processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ log/*
 !/data/.keep
 !/data/paleontology
 
+# ignore files created by import process
+/public/as_export
+/public/ead
+/public/html


### PR DESCRIPTION
We want to avoid checking static files that are dynamically generated by the import process from being committed to GitHub.