### PR TITLE
Changing solr_wrapper download directory per documented options

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,6 +1,6 @@
 # Place any default configuration for solr_wrapper here
 version: 8.8.2
-solr_zip_path: tmp/solr_install
+download_dir: tmp
 instance_dir: tmp/solr_instance
 # port: 8983
 collection:


### PR DESCRIPTION
Changing the solr_wrapper option for the downloaded Solr compressed binary.  Was previously changed to be `solr_zip_path: tmp/solr_install`, which resulted in a compressed file named `solr_install`, which is potentially confusing without the extension. The `solr_zip_path` option also appears to have been deprecated in 4.x.

Using the documented option of `download_dir` will instead maintain the original artifact name (i.e. `solr-8.8.2.zip`) stored in the provided directory name.  The location is set to the `tmp` directory relative to the project.