### PR TITLE
Update the summary date formatting in printed finding aids

### DIFF
--- a/app/templates/template.xslt
+++ b/app/templates/template.xslt
@@ -462,17 +462,22 @@
 					</td>
 					<td>
 						<xsl:for-each select="unitdate">
-							<xsl:choose>
-								<xsl:when test="@encodinganalog='245$f'">
-									<xsl:value-of select="."/>
-								</xsl:when>
-								<xsl:when test="@encodinganalog='245$g'">
-									(bulk: <xsl:value-of select="."/>)
-								</xsl:when>
-								<xsl:otherwise>
-									<xsl:value-of select="."/>
-								</xsl:otherwise>
-							</xsl:choose>
+							<!-- display type if there are additional unitdate nodes -->
+							<xsl:if test="position() != 1">
+								<xsl:value-of select="@type"/>
+								<xsl:text> </xsl:text>
+							</xsl:if>
+							<xsl:if test="@encodinganalog='245$g'">
+								<xsl:text>bulk </xsl:text>
+							</xsl:if>
+
+							<!-- display the unitdate -->
+							<xsl:value-of select="."/>
+
+							<!-- separate multiple entries with a comma -->
+							<xsl:if test="position() != last()">
+								<xsl:text>, </xsl:text>
+							</xsl:if>
 						</xsl:for-each>
 					</td>
 				</tr>


### PR DESCRIPTION
refs [AR-140](https://bugs.dlib.indiana.edu/browse/AR-140) Page Titles

# Summary
This change adds additional formatting to the dates in the collection
overview &lt;archdesc/did:gt; section of the finding aid.

This commit:
* Displays the type (bulk, etc.) of additional &lt;unitdate&gt; nodes
after the first if there are more than one
* Separates multiple &lt;unitdate&gt; nodes with commas

# Before
<img width="903" alt="image" src="https://user-images.githubusercontent.com/3064318/174652081-0daf37bb-f41d-488b-97be-369a0bef9ba8.png">

# After 
<img width="971" alt="image" src="https://user-images.githubusercontent.com/3064318/174652415-0dcbc697-bff4-40c7-9f23-ab83232a5729.png">
