### PR TITLE
Format extent in printed finding aid overview section

### DIFF
--- a/app/templates/template.xslt
+++ b/app/templates/template.xslt
@@ -1353,14 +1353,14 @@
 		</xsl:template>
 
 
-                <!-- Adds parens around extent elements in inventory listing but not in archdesc/did -->
+	    <!-- Adds parens around extent elements except for the first entry in archdesc/did -->
 		<xsl:template match="extent">
 			<xsl:choose>
-				<xsl:when test="ancestor::c01|c02|co3|co4|co5|co6|c07|c08">
-					(<xsl:apply-templates />)
+				<xsl:when test="ancestor::did and position() = 1">
+					<xsl:apply-templates/>
 				</xsl:when>
 				<xsl:otherwise>
-					<xsl:apply-templates/>
+					(<xsl:apply-templates/>)
 				</xsl:otherwise>
 			</xsl:choose>
 		</xsl:template>


### PR DESCRIPTION
refs [AR-140](https://bugs.dlib.indiana.edu/browse/AR-140) Page Titles

This change adds additional formatting to the extents in the collection
overview &lt;archdesc/did&gt; section of the finding aid.

This commit:
* Wraps any extent after the first in parenthesis
# Before
<img width="790" alt="image" src="https://user-images.githubusercontent.com/3064318/174660685-b22483e2-b0dc-4964-805c-d426aa2ec9cd.png">

# After
<img width="790" alt="image" src="https://user-images.githubusercontent.com/3064318/174660232-7eeec0fd-b73f-4396-a405-162d3460d84d.png">
