### PR TITLE
Improve formatting of main finding aid sections

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -23,6 +23,10 @@ body.ead-print {
   font-family: GeorgiaProRegular, Georgia, "Times New Roman", Times, serif;
 }
 
+.no-bullets {
+  list-style-type: none;
+}
+
 div.title-block {
   text-align: center;
   padding-bottom: 1rem;
@@ -71,13 +75,50 @@ div.archdesc-section {
     margin-block-start: 0.25rem;
   }
 
-  .subject-headings > * h5 {
-    font-size: 110%;
-    margin-block-start: 0;
-    margin-block-end: 0;
+  ul.subject-headings {
+    list-style-type: none;
+    margin: 0;
+
+    h5 {
+      font-size: 100%;
+      margin-block-start: 0;
+      margin-block-end: 0;
+    }
+
+    ul {
+      list-style-type: none;
+      padding-left: 0;
+    }
   }
 
   li.subj-label {
     margin-bottom: 0.75rem;
+  }
+}
+
+div.archdesc-section.restrict {
+  h4 {
+    display: inline;
+    margin-right: .5rem;
+    margin-top: 0;
+    margin-bottom: 0;
+    float: left;
+  }
+}
+
+div.archdesc-section.admininfo {
+  .subhead-1 {
+    font-weight: bold;
+    display: inline;
+  }
+}
+
+table.dcs-components {
+  td.container-id {
+    width: 7rem;
+  }
+
+  tr:nth-child(odd) {
+    background-color: lightgray;
   }
 }

--- a/app/templates/template.xslt
+++ b/app/templates/template.xslt
@@ -3,7 +3,7 @@
 <!--  an original copy can be found here:                                                    -->
 <!--  https://github.com/saa-ead-roundtable/ead-stylesheets/tree/master/print-friendly-html  -->
 
-	<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 	<xsl:strip-space elements="*"/>
 	<xsl:output method="html" encoding="UTF-8" doctype-public="-//W3C//DTD HTML 4.0 Transitional//EN"/>
 	<!-- Creates the body of the finding aid.-->
@@ -13,7 +13,7 @@
 			<!-- Outputs header information for the HTML document 			-->
 			<!-- ****************************************************************** -->
 			<head>
-				<link rel="stylesheet" href="/assets/print.scss" />
+				<link rel="stylesheet" href="/assets/print.scss"/>
 				<link rel="shortcut icon" type="image/x-icon" href="/assets/favicon.ico"/>
 				<title>
 					<xsl:apply-templates select="eadheader/filedesc/titlestmt/titleproper"/>
@@ -36,41 +36,41 @@
 						<xsl:apply-templates select="eadheader/filedesc/titlestmt/author"/>
 					</p>
 				</div>
-				
+
 				<!--To change the order of display, adjust the sequence of
 				the following apply-template statements which invoke the various
 				templates that populate the finding aid.  Multiple statements
 				are included to handle the possibility that descgrp has been used
 				as a wrapper to replace add and admininfo.  In several cases where
 				multiple elements are displayed together in the output, a call-template
-				statement is used -->	
-					
-				<xsl:apply-templates select="archdesc/did"/>
-				<p class="breakhere"></p>
-				<xsl:apply-templates select="archdesc/bioghist"/>
-				<xsl:apply-templates select="archdesc/scopecontent"/>
-				<xsl:apply-templates select="archdesc/arrangement"/>
-				<xsl:apply-templates select="archdesc/otherfindaid | archdesc/*/otherfindaid"/>
-				<xsl:call-template name="archdesc-restrict"/>
-				<xsl:call-template name="archdesc-relatedmaterial"/>
-				<xsl:apply-templates select="archdesc/controlaccess"/>
-				<xsl:apply-templates select="archdesc/odd"/>
-				<xsl:apply-templates select="archdesc/originalsloc"/>
-				<xsl:apply-templates select="archdesc/phystech"/>
-				<xsl:call-template name="archdesc-admininfo"/>
-				<xsl:apply-templates select="archdesc/fileplan | archdesc/*/fileplan"/>
-				<xsl:apply-templates select="archdesc/bibliography | archdesc/*/bibliography"/>
-				<xsl:call-template name="toc"/>
-				<xsl:apply-templates select="archdesc/dsc"/>	
-				<hr/>			
-				<xsl:apply-templates select="archdesc/index | archdesc/*/index"/>
+				statement is used -->
+
+				<div class="archdesc-overview">
+					<xsl:apply-templates select="archdesc/did"/>
+				</div>
+
+				<div class="archdesk-main">
+					<xsl:apply-templates select="archdesc/bioghist"/>
+					<xsl:apply-templates select="archdesc/scopecontent"/>
+					<xsl:apply-templates select="archdesc/arrangement"/>
+					<xsl:apply-templates select="archdesc//otherfindaid"/>
+					<xsl:call-template name="archdesc-restrict"/>
+					<xsl:apply-templates select="archdesc/separatedmaterial"/>
+					<xsl:apply-templates select="archdesc/relatedmaterial"/>
+					<xsl:apply-templates select="archdesc/controlaccess"/>
+					<xsl:apply-templates select="archdesc/odd"/>
+					<xsl:apply-templates select="archdesc/originalsloc"/>
+					<xsl:apply-templates select="archdesc/phystech"/>
+					<xsl:call-template name="archdesc-admininfo"/>
+					<xsl:apply-templates select="archdesc/fileplan | archdesc/*/fileplan"/>
+					<xsl:apply-templates select="archdesc/bibliography | archdesc/*/bibliography"/>
+					<xsl:call-template name="toc"/>
+					<xsl:apply-templates select="archdesc/dsc"/>
+					<xsl:apply-templates select="archdesc/index | archdesc/*/index"/>
+				</div>
 			</body>
 		</html>
 	</xsl:template>
-
-
-
-
 
 
 	<!-- ****************************************************************** -->
@@ -82,8 +82,10 @@
 	<!-- ****************************************************************** -->
 
 	<xsl:template name="toc">
-
-		<h3>Table of Contents</h3>
+		<div class="archdesc-section toc">
+			<h3>
+				<xsl:text>Table of Contents</xsl:text>
+			</h3>
 
 		<!-- *************************************************	-->
 		<!-- Captures unittitle and unitdates for c01's whose	-->
@@ -91,30 +93,35 @@
 		<!-- subseries, and generates TOC (no page #s)  	-->
 		<!-- *************************************************	-->
 
-		<xsl:for-each select="archdesc/dsc/c01[@level='series' or @level='subseries'
-		or @level='subgrp' or @level='subcollection']">
-			<p class="toc-para1">
-				<xsl:choose>
-					<xsl:when test="did/unittitle/unitdate">
-						<xsl:for-each select="did/unittitle">
-							<xsl:value-of select="text()"/>
-							<xsl:text> </xsl:text>
-							<xsl:apply-templates select="./unitdate"/>
-						</xsl:for-each>
-					</xsl:when>
-					<xsl:otherwise>
-						<xsl:apply-templates select="did/unittitle"/>
-						<xsl:text> </xsl:text>
-						<xsl:apply-templates select="did/unitdate"/>
-					</xsl:otherwise>
-				</xsl:choose>
-			</p>
-		</xsl:for-each>
-		<xsl:for-each select="archdesc/index | archdesc/*/index">
-			<p class="toc-para1"><xsl:apply-templates select="head"/></p>
-		</xsl:for-each>
-		<hr/>
-		<!-- <p class="breakhere"/> -->
+			<xsl:for-each select="archdesc/dsc/c01[@level='series' or @level='subseries'
+		                          or @level='subgrp' or @level='subcollection']">
+				<ul class="toc-para1">
+					<xsl:choose>
+						<xsl:when test="did/unittitle/unitdate">
+							<xsl:for-each select="did/unittitle">
+								<li>
+									<xsl:value-of select="text()"/>
+									<xsl:text> </xsl:text>
+									<xsl:apply-templates select="./unitdate"/>
+								</li>
+							</xsl:for-each>
+						</xsl:when>
+						<xsl:otherwise>
+							<li>
+								<xsl:apply-templates select="did/unittitle"/>
+								<xsl:text> </xsl:text>
+								<xsl:apply-templates select="did/unitdate"/>
+							</li>
+						</xsl:otherwise>
+					</xsl:choose>
+				</ul>
+			</xsl:for-each>
+			<xsl:for-each select="archdesc/index | archdesc/*/index">
+				<p class="toc-para1">
+					<xsl:apply-templates select="head"/>
+				</p>
+			</xsl:for-each>
+		</div>
 	</xsl:template>
 
 
@@ -123,19 +130,23 @@
 	<!-- Also BLOCKQUOTE handling                                           -->
 	<!-- ****************************************************************** -->
 
+	<xsl:template match="p">
+		<p>
+			<xsl:apply-templates/>
+		</p>
+	</xsl:template>
+
 	<xsl:template match="blockquote">
 		<blockquote>
 			<xsl:apply-templates/>
 		</blockquote>
 	</xsl:template>
 
-
 	<xsl:template match="blockquote/p">
 		<blockquote>
 			<xsl:apply-templates/>
 		</blockquote>
 	</xsl:template>
-
 
 	<xsl:template match="emph[@render='bold']">
 		<b>
@@ -212,52 +223,38 @@
 
 	</xsl:template>
 
-
 	
 	<!-- ****************************************************************** -->
-	<!-- LIST								-->
-	<!-- Formats a list anywhere except in ARRANGEMENT or REVISIONDESC.   	-->
-	<!-- Two values for attribute TYPE are implemented: "simple" gives   	-->
-	<!-- an indented list with no marker, "marked" gives an indented list  	-->
-	<!-- with each item bulleted.						-->
+	<!-- LIST                                                               -->
+	<!-- Formats a list anywhere except in ARRANGEMENT or REVISIONDESC.     -->
+	<!-- Two values for attribute TYPE are implemented: "simple" gives      -->
+	<!-- an indented list with no marker, "marked" gives an indented list   -->
+	<!-- with each item bulleted, "ordered" gives a numbered list.          -->
 	<!-- ****************************************************************** -->
 
-        
-	<xsl:template match="archdesc/scopecontent/list">
-		<div style="margin-left: 25pt">
+
+	<xsl:template match="list[@type='ordered']">
+		<ol>
 			<xsl:apply-templates/>
-		</div>
+		</ol>
 	</xsl:template>
 
-
-	<xsl:template match="list[parent::*[not(self::arrangement)]]/head">
-		<div style="margin-left: 25pt">
-			<b>
-				<xsl:apply-templates/>
-			</b>
-		</div>
+	<xsl:template match="list[@type='simple']">
+		<ol class="no-bullets">
+			<xsl:apply-templates/>
+		</ol>
 	</xsl:template>
 
-
-	<xsl:template match="list[parent::*[not((self::arrangement)|(self::revisiondesc))]]/item">
-		<xsl:if test="@id">
-			<a id="{@id}"></a>
-		</xsl:if>
-		<xsl:choose>
-			<xsl:when test="parent::list[@type='marked']">
-				<div style="margin-left: 25pt">
-					&#x2022; <xsl:apply-templates/>
-				</div>
-			</xsl:when>
-			<xsl:otherwise>
-				<div style="margin-left: 25pt"><xsl:apply-templates/></div>
-			</xsl:otherwise>
-		</xsl:choose>
+	<xsl:template match="list">
+		<ul>
+			<xsl:apply-templates/>
+		</ul>
 	</xsl:template>
 
-
-	<xsl:template match="list[parent::*[not(self::arrangement)]]/item/note">
-		<i><xsl:apply-templates/></i>
+	<xsl:template match="list/item">
+		<li>
+			<xsl:apply-templates/>
+		</li>
 	</xsl:template>
 
 
@@ -441,49 +438,13 @@
 	<!-- ****************************************************************** -->
 
 	<xsl:template match="archdesc/did">
-		<table width="100%" class="overview">
-			<tr>
-				<td width="10%"> </td>
-				<td> </td>
-			</tr>
-			<tr>
-				<td colspan="2">
-					<h3><xsl:apply-templates select="head"/></h3>
-				</td>
-			</tr>	
-
+		<div class="archdesc did">
+		<table class="overview">
 			<xsl:apply-templates select="origination"/>	
-			<xsl:apply-templates select="unittitle"/>	
-			<!-- <xsl:apply-templates select="unitdate"/> -->
-			<xsl:if test="unitdate">
-				<tr>	
-					<td valign="top">
-						<b>Dates:</b>
-					</td>
-					<td>
-						<xsl:for-each select="unitdate">
-							<!-- display type if there are additional unitdate nodes -->
-							<xsl:if test="position() != 1">
-								<xsl:value-of select="@type"/>
-								<xsl:text> </xsl:text>
-							</xsl:if>
-							<xsl:if test="@encodinganalog='245$g'">
-								<xsl:text>bulk </xsl:text>
-							</xsl:if>
-
-							<!-- display the unitdate -->
-							<xsl:value-of select="."/>
-
-							<!-- separate multiple entries with a comma -->
-							<xsl:if test="position() != last()">
-								<xsl:text>, </xsl:text>
-							</xsl:if>
-						</xsl:for-each>
-					</td>
-				</tr>
-			</xsl:if>	
-			<xsl:apply-templates select="physdesc"/>	
-			<xsl:apply-templates select="abstract"/>	
+			<xsl:apply-templates select="unittitle"/>
+			<xsl:apply-templates select="unitdate[1]"/>
+			<xsl:apply-templates select="physdesc"/>
+			<xsl:apply-templates select="abstract"/>
 			<!-- <xsl:apply-templates select="unitid"/>  -->
 			<xsl:apply-templates select="physloc"/>
 			<xsl:apply-templates select="langmaterial"/>
@@ -491,9 +452,8 @@
 			<xsl:apply-templates select="materialspec"/>
 			<xsl:apply-templates select="note"/>
 		</table>
-		<hr/>
+		</div>
 	</xsl:template>
-
 
 
 	<!-- ****************************************************************** -->
@@ -506,6 +466,8 @@
 
 	<xsl:template match="archdesc/did/repository
 	| archdesc/did/origination
+	| archdesc/did/unittitle
+	| archdesc/did/unitdate
 	| archdesc/did/physdesc
 	| archdesc/did/unitid
 	| archdesc/did/physloc
@@ -518,166 +480,83 @@
 	<!-- a label is supplied (to alter supplied text, make change below).	-->
 	<!-- ****************************************************************** -->
 
-		<xsl:choose>
-			<xsl:when test="@label">
-				<tr>
-				
-					<td valign="top">
-						<b>
-							<xsl:value-of select="@label"/>
-						</b>
-					</td>
-					<td>
-						<xsl:apply-templates/>
-					</td>
-				</tr>
-			</xsl:when>
-			<xsl:otherwise>
-				<tr>
-					<td valign="top">
-						<b>
-							<xsl:choose>
-								<xsl:when test="self::repository">
-									<xsl:text>Repository: </xsl:text>
-								</xsl:when>
-								<xsl:when test="self::origination">
-									<xsl:text>Creator: </xsl:text>
-								</xsl:when>
-								<xsl:when test="self::physdesc">
-									<xsl:text>Quantity: </xsl:text>
-								</xsl:when>
-								<xsl:when test="self::physloc">
-									<xsl:text>Location: </xsl:text>
-								</xsl:when>
-								<xsl:when test="self::unitid">
-									<xsl:text>Identification: </xsl:text>
-								</xsl:when>
-								<xsl:when test="self::abstract">
-									<xsl:text>Abstract:</xsl:text>
-								</xsl:when>
-								<xsl:when test="self::langmaterial">
-									<xsl:text>Language: </xsl:text>
-								</xsl:when>
-								<xsl:when test="self::materialspec">
-									<xsl:text>Technical: </xsl:text>
-								</xsl:when>
-							</xsl:choose>
-						</b>
-					</td>
-					<td>
-						<xsl:apply-templates/>
-					</td>
-				</tr>
-			</xsl:otherwise>
-		</xsl:choose>
+		<tr>
+			<td class="did-label">
+				<xsl:choose>
+					<!-- Use @label if it exists -->
+					<xsl:when test="@label">
+						<xsl:value-of select="@label"/>
+						<xsl:text>:</xsl:text>
+					</xsl:when>
+
+					<!--Otherwise, use default label based on the node type  -->
+					<xsl:when test="self::unittitle">
+						<xsl:text>Title:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::repository">
+						<xsl:text>Repository:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::origination">
+						<xsl:text>Creator:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::physdesc">
+						<xsl:text>Quantity:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::physloc">
+						<xsl:text>Location:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::unitid">
+						<xsl:text>Identification:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::unitdate">
+						<xsl:text>Dates:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::abstract">
+						<xsl:text>Abstract:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::langmaterial">
+						<xsl:text>Language:</xsl:text>
+					</xsl:when>
+					<xsl:when test="self::materialspec">
+						<xsl:text>Technical:</xsl:text>
+					</xsl:when>
+
+					<!-- Include an easily searchable fail-over label in case we missed any node types -->
+					<xsl:otherwise>
+						<xsl:text>ID Section:</xsl:text>
+					</xsl:otherwise>
+				</xsl:choose>
+			</td>
+			<td class="did-value">
+				<xsl:apply-templates/>
+			</td>
+		</tr>
 	</xsl:template>
 
 	<!-- ****************************************************************** -->
-	<!-- UNITTITLE, UNITDATE						-->
-	<!-- If @LABEL is present it is used, otherwise a label is generated.	-->
+	<!-- UNITDATE                                                           -->
+	<!-- Concatenate all <unitdate> sibling nodes & display @type           -->
 	<!-- ****************************************************************** -->
 
-	<xsl:template match="archdesc/did/unittitle">
+	<xsl:template match="unitdate/child::text()">
+	   <xsl:for-each select="parent::node()/../unitdate">
+		   <!-- display type if there are additional unitdate nodes -->
+		   <xsl:if test="position() != 1">
+			   <xsl:value-of select="@type"/>
+			   <xsl:text> </xsl:text>
+		   </xsl:if>
+		   <xsl:if test="@encodinganalog='245$g'">
+			   <xsl:text>bulk </xsl:text>
+		   </xsl:if>
 
-		<xsl:choose>
+		   <!-- display the unitdate -->
+		   <xsl:value-of select="."/>
 
-			<xsl:when test="@label">
-				<tr>
-					
-					<td valign="top">
-						<b>
-							<xsl:value-of select="@label"/>
-						</b>
-					</td>
-					<td>
-						<xsl:apply-templates select="text() |* [not(self::unitdate)]"/>
-					</td>
-				</tr>
-			</xsl:when>
-		
-			<xsl:otherwise>
-				<tr>
-					
-					<td valign="top">
-						<b>
-							<xsl:text>Title: </xsl:text>
-						</b>
-					</td>
-					<td>
-						<xsl:apply-templates select="text() |* [not(self::unitdate)]"/>
-					</td>
-				</tr>
-
-			</xsl:otherwise>
-
-		</xsl:choose>
-
-
-		<xsl:if test="child::unitdate">
-
-			<xsl:choose>
-				<xsl:when test="unitdate/@label">
-					<tr>
-						
-						<td valign="top">
-							<b>
-								<xsl:value-of select="unitdate/@label"/>
-							</b>
-						</td>
-						<td>
-							<xsl:apply-templates select="unitdate"/>
-						</td>
-					</tr>
-				</xsl:when>
-	
-				<xsl:otherwise>
-					<tr>
-						
-						<td valign="top">
-							<b>
-								<xsl:text>Dates: </xsl:text>
-							</b>
-						</td>
-						<td>
-							<xsl:apply-templates select="unitdate"/>
-						</td>
-					</tr>
-				</xsl:otherwise>
-			</xsl:choose>
-		</xsl:if>
-	</xsl:template>
-
-	<xsl:template match="archdesc/did/unitdate">
-
-		<xsl:choose>
-			<xsl:when test="@label">
-				<tr>
-					
-					<td valign="top">
-						<b>
-							<xsl:value-of select="@label"/>
-						</b>
-					</td>
-					<td>
-						<xsl:apply-templates/>
-					</td>
-				</tr>
-			</xsl:when>
-		
-			<xsl:otherwise>
-				<tr>
-				
-					<td valign="top">
-						<b>
-							<xsl:text>Dates: </xsl:text>
-						</b>
-					</td>
-					<td>
-						<xsl:apply-templates/>
-					</td>
-				</tr>
-			</xsl:otherwise>
-		</xsl:choose>
+		   <!-- separate multiple entries with a comma -->
+		   <xsl:if test="position() != last()">
+			   <xsl:text>, </xsl:text>
+		   </xsl:if>
+	   </xsl:for-each>
 	</xsl:template>
 
 	
@@ -760,40 +639,28 @@
 	<!-- ****************************************************************** -->
 
 	<xsl:template match="archdesc/bioghist |
-			archdesc/scopecontent |
-			archdesc/phystech |
-			archdesc/odd   |
-			archdesc/arrangement">
-		<xsl:if test="string(child::*)">	
+		archdesc/scopecontent |
+		archdesc/phystech |
+		archdesc/odd   |
+		archdesc/arrangement |
+		archdesc/separatedmaterial |
+		archdesc/relatedmaterial |
+		archdesc/controlaccess |
+		archdesc/otherfindaid | archdesc/*/otherfindaid |
+		archdesc/originalsloc |
+		archdesc/fileplan | archdesc/*/fileplan |
+		archdesc/bibliography | archdesc/*/bibliography |
+		archdesc/dsc">
+		<div>
+			<xsl:attribute name="class">archdesc-section
+				<xsl:value-of select="name()"/>
+			</xsl:attribute>
 			<xsl:apply-templates/>
-			<hr/>
-		</xsl:if>
+		</div>
 	</xsl:template>
 
-	<xsl:template match="archdesc/bioghist/head  |
-			archdesc/scopecontent/head |
-			archdesc/arrangement/head |
-			archdesc/phystech/head |
-			archdesc/controlaccess/head |
-			archdesc/odd/head">
+	<xsl:template match="archdesc/*/head">
 		<h3><xsl:apply-templates/></h3>
-	</xsl:template>
-
-	<xsl:template match="archdesc/bioghist/p |
-			archdesc/bioghist/note/p |
-			archdesc/scopecontent/p |
-			archdesc/scopecontent/note/p |
-			archdesc/arrangement/p |
-			archdesc/arrangement/note/p |
-			archdesc/phystech/p |
-			archdesc/phystech/note/p |
-			archdesc/controlaccess/p |
-			archdesc/controlaccess/note/p |
-			archdesc/odd/p |
-			archdesc/odd/note/p">
-		<p class="inv-1">
-			<xsl:apply-templates/>
-		</p>
 	</xsl:template>
 
 
@@ -802,76 +669,32 @@
 	<scopecontent>.-->
 	
 	<xsl:template match="archdesc/scopecontent/arrangement/list/head">
-		<div style="margin-left:25pt">
+		<div class="arrangement-list arrangement-list-head">
 			<xsl:apply-templates/>
 		</div>
 	</xsl:template>
 	
 	<xsl:template match="archdesc/arrangement/list/head">
-		<div style="margin-left:25pt">
-			<xsl:apply-templates/>
-		</div>
-	</xsl:template>
-	
-	<xsl:template match="archdesc/scopecontent/arrangement/list/item |
-			     archdesc/arrangement/list/item">
-		<div style="margin-left:50pt">
+		<div class="arrangement-list arrangement-list-head">
 			<xsl:apply-templates/>
 		</div>
 	</xsl:template>
 
-
-
-	<!-- ****************************************************************** -->
-	<!-- RELATED MATERIAL, SEPARATED MATERIAL Processing			-->
-	<!-- Formats the top-level related material elements by combining any 	-->
-	<!-- related or separated materials elements. Test for RELATEDMATERIAL	-->
-	<!-- or SEPARATEDMATERIAL elements with content; if present they are	-->
-	<!-- combined.  Includes processing of any NOTE or LIST child elements.	-->
-	<!-- ****************************************************************** -->
-	
-	<xsl:template name="archdesc-relatedmaterial">
-		<xsl:if test="string(archdesc/relatedmaterial) or
-		string(archdesc/*/relatedmaterial) or
-		string(archdesc/separatedmaterial) or
-		string(archdesc/*/separatedmaterial)">
-			<h3>
-				<b>
-					<xsl:text>Related Material</xsl:text>
-				</b>
-			</h3>
-
-			<xsl:apply-templates select="archdesc/separatedmaterial/p
-				| archdesc/*/separatedmaterial/p
-				| archdesc/separatedmaterial/blockquote
-				| archdesc/separatedmaterial/note/p
-				| archdesc/*/separatedmaterial/note/p
-				| archdesc/separatedmaterial/list"/>
-
-			<xsl:apply-templates select="archdesc/relatedmaterial/p
-				| archdesc/relatedmaterial/blockquote
-				| archdesc/*/relatedmaterial/p
-				| archdesc/relatedmaterial/note/p
-				| archdesc/*/relatedmaterial/note/p
-				| archdesc/relatedmaterial/list"/>
-			<hr/>
-		</xsl:if>
-	</xsl:template>
-	
-	<xsl:template match="archdesc/relatedmaterial/p
-		| archdesc/*/relatedmaterial/p
-		| archdesc/separatedmaterial/p
-		| archdesc/*/separatedmaterial/p
-		| archdesc/relatedmaterial/note/p
-		| archdesc/*/relatedmaterial/note/p
-		| archdesc/separatedmaterial/note/p
-		| archdesc/*/separatedmaterial/note/p
-		| archdesc/separatedmaterial/list
-		| archdesc/relatedmaterial/list">
-		<p class="inv-1">
+	<xsl:template match="archdesc/scopecontent/arrangement/list |
+			     archdesc/arrangement/list">
+		<ul class="arrangement-list">
 			<xsl:apply-templates/>
-		</p>
+		</ul>
 	</xsl:template>
+
+	
+	<xsl:template match="archdesc/scopecontent/arrangement/list//item |
+			     archdesc/arrangement/list//item">
+		<li>
+			<xsl:apply-templates/>
+		</li>
+	</xsl:template>
+
 
 
 	<!-- ****************************************************************** -->
@@ -884,72 +707,90 @@
 	<!-- ****************************************************************** -->
 	
 	<xsl:template match="archdesc/controlaccess">
-		<xsl:if test="string(child::*)">
-			<h3><b>Subject Headings</b></h3>
-			<xsl:if test="persname | famname">
-				<p class="subhead-1">Persons</p>
-				<p class="subhead-2">
-					<xsl:for-each select="famname | persname">
-						<xsl:sort select="." data-type="text" order="ascending"/>
-						<xsl:apply-templates/><br/>
-					</xsl:for-each>
-				</p>
-			</xsl:if>
-			<xsl:if test="corpname">
-				<p class="subhead-1">Corporate Bodies</p>
-				<p class="subhead-2">
-					<xsl:for-each select="corpname">
-						<xsl:sort select="." data-type="text" order="ascending"/>
-						<xsl:apply-templates/><br/>
-					</xsl:for-each>
-				</p>
-			</xsl:if>
-			<xsl:if test="title">
-				<p class="subhead-1">Associated Titles</p>
-        <p class="subhead-2">
-					<xsl:for-each select="title">
-						<xsl:sort select="." data-type="text" order="ascending"/>
-						<xsl:apply-templates/><br/>
-					</xsl:for-each>
-				</p>
-			</xsl:if>
-			<xsl:if test="subject">
-				<p class="subhead-1">Subjects</p>
-        <p class="subhead-2">
-					<xsl:for-each select="subject">
-						<xsl:sort select="." data-type="text" order="ascending"/>
-						<xsl:apply-templates/><br/>
-					</xsl:for-each>
-				</p>
-			</xsl:if>
-			<xsl:if test="geogname">
-				<p class="subhead-1">Places</p>
-        <p class="subhead-2">
-					<xsl:for-each select="geogname">
-						<xsl:sort select="." data-type="text" order="ascending"/>
-						<xsl:apply-templates/><br/>
-					</xsl:for-each>
-				</p>
-			</xsl:if>
-			<xsl:if test="genreform">
-				<p class="subhead-1">Genres and Forms</p>
-        <p class="subhead-2">
-					<xsl:for-each select="genreform">
-						<xsl:sort select="." data-type="text" order="ascending"/>
-						<xsl:apply-templates/><br/>
-					</xsl:for-each>
-				</p>
-			</xsl:if>
-			<xsl:if test="occupation | function">
-				<p class="subhead-1">Occupations</p>
-        <p class="subhead-2">
-					<xsl:for-each select="occupation | function">
-						<xsl:sort select="." data-type="text" order="ascending"/>
-						<xsl:apply-templates/><br/>
-					</xsl:for-each>
-				</p>
-			</xsl:if>
-		</xsl:if>
+		<div class="archdesc-section controlaccess">
+			<h3>Subject Headings</h3>
+			<ul class="subject-headings">
+				<xsl:for-each select=".">
+					<xsl:if test="persname | famname">
+						<li class="subj-label">
+							<h5>Persons</h5>
+							<ul class="subj-values">
+								<xsl:for-each select="famname | persname">
+									<xsl:sort select="." data-type="text" order="ascending"/>
+									<li><xsl:apply-templates/></li>
+								</xsl:for-each>
+							</ul>
+						</li>
+					</xsl:if>
+					<xsl:if test="corpname">
+						<li class="subj-label">
+							<h5>Corporate Bodies</h5>
+							<ul class="subj-values">
+								<xsl:for-each select="corpname">
+									<xsl:sort select="." data-type="text" order="ascending"/>
+									<li><xsl:apply-templates/></li>
+								</xsl:for-each>
+							</ul>
+						</li>
+					</xsl:if>
+					<xsl:if test="title">
+						<li class="subj-label">
+							<h5>Associated Titles</h5>
+							<ul class="subj-values">
+								<xsl:for-each select="title">
+									<xsl:sort select="." data-type="text" order="ascending"/>
+									<li><xsl:apply-templates/></li>
+								</xsl:for-each>
+							</ul>
+						</li>
+					</xsl:if>
+					<xsl:if test="subject">
+						<li class="subj-label">
+							<h5>Subjects</h5>
+							<ul class="subj-values">
+								<xsl:for-each select="subject">
+									<xsl:sort select="." data-type="text" order="ascending"/>
+									<li><xsl:apply-templates/></li>
+								</xsl:for-each>
+							</ul>
+						</li>
+					</xsl:if>
+					<xsl:if test="geogname">
+						<li class="subj-label">
+							<h5>Places</h5>
+							<ul class="subj-values">
+								<xsl:for-each select="geogname">
+									<xsl:sort select="." data-type="text" order="ascending"/>
+									<li><xsl:apply-templates/></li>
+								</xsl:for-each>
+							</ul>
+						</li>
+					</xsl:if>
+					<xsl:if test="genreform">
+						<li class="subj-label">
+							<h5>Genres and Forms</h5>
+							<ul class="subj-values">
+								<xsl:for-each select="genreform">
+									<xsl:sort select="." data-type="text" order="ascending"/>
+									<li><xsl:apply-templates/></li>
+								</xsl:for-each>
+							</ul>
+						</li>
+					</xsl:if>
+					<xsl:if test="occupation | function">
+						<li class="subj-label">
+							<h5>Occupationss</h5>
+							<ul class="subj-values">
+								<xsl:for-each select="occupation | function">
+									<xsl:sort select="." data-type="text" order="ascending"/>
+									<li><xsl:apply-templates/></li>
+								</xsl:for-each>
+							</ul>
+						</li>
+					</xsl:if>
+				</xsl:for-each>
+			</ul>
+		</div>
 	</xsl:template>
 
 
@@ -960,40 +801,25 @@
 
 	<xsl:template name="archdesc-restrict">
 		<xsl:if test="string(archdesc/userestrict/*)
-		or string(archdesc/accessrestrict/*)
-		or string(archdesc/*/userestrict/*)
-		or string(archdesc/*/accessrestrict/*)">
-			<h3><b><xsl:text>Restrictions</xsl:text></b></h3>
-                        
-			<p class="inv-1"> 
-				<xsl:apply-templates select="archdesc/accessrestrict |
-									archdesc/*/accessrestrict"/>
-			</p>
-			<p class="inv-1">
-				<xsl:apply-templates select="archdesc/userestrict | 
-							     archdesc/*/userestrict"/>
-			</p>
-			<hr/>
+		or string(archdesc/accessrestrict/*)">
+			<div class="archdesc-section restrict">
+				<h3><xsl:text>Restrictions</xsl:text></h3>
+
+				<div class="accessrestrict">
+					<xsl:apply-templates select="archdesc/accessrestrict"/>
+				</div>
+
+				<div class="userrestrict">
+					<xsl:apply-templates select="archdesc/userestrict"/>
+				</div>
+			</div>
 		</xsl:if>
 	</xsl:template>
 
-	<xsl:template match="archdesc/accessrestrict/head |
-			     archdesc/userestrict/head">
-		<b><xsl:apply-templates/></b>: 
+	<xsl:template match="archdesc//accessrestrict/head |
+			     archdesc//userestrict/head">
+		<h4><xsl:apply-templates/>: </h4>
 	</xsl:template>
-
-
-	<xsl:template match="archdesc/accessrestrict/p
-	| archdesc/userestrict/p
-	| archdesc/*/accessrestrict/p
-	| archdesc/*/userestrict/p
-	| archdesc/accessrestrict/note/p
-	| archdesc/userestrict/note/p
-	| archdesc/*/accessrestrict/note/p
-	| archdesc/*/userestrict/note/p">
-		<xsl:apply-templates/>
-	</xsl:template>
-
 
 
 	<!-- ****************************************************************** -->
@@ -1003,7 +829,7 @@
 	<!-- heading, "Administrative Information."  If child elements contain	-->
 	<!-- a HEAD element it is retained and used as the section title.	-->
 	<!-- ****************************************************************** -->
-	 
+
 	<xsl:template name="archdesc-admininfo">
 		<xsl:if test="string(archdesc/admininfo/custodhist/*)
 		or string(archdesc/altformavail/*)
@@ -1019,25 +845,26 @@
 		or string(archdesc/*/processinfo/*)
 		or string(archdesc/*/appraisal/*)
 		or string(archdesc/*/accruals/*)">
-			<h3>
-				<xsl:text>Administrative Information</xsl:text>
-			</h3>
-			<xsl:apply-templates select="archdesc/custodhist
-				| archdesc/*/custodhist"/>
-			<xsl:apply-templates select="archdesc/altformavail
-				| archdesc/*/altformavail"/>
-			<xsl:apply-templates select="archdesc/prefercite
-				| archdesc/*/prefercite"/>
-			<xsl:apply-templates select="archdesc/acqinfo
-				| archdesc/*/acqinfo"/>
-			<xsl:apply-templates select="archdesc/processinfo
-				| archdesc/*/processinfo"/>
-			<xsl:apply-templates select="archdesc/admininfo/appraisal
-				| archdesc/*/appraisal"/>
-			<xsl:apply-templates select="archdesc/admininfo/accruals
-				| archdesc/*/accruals"/>
+			<div class="archdesc-section admininfo">
+				<h3>
+					<xsl:text>Administrative Information</xsl:text>
+				</h3>
 
-			<hr/>
+				<xsl:apply-templates select="archdesc/custodhist
+				| archdesc/*/custodhist"/>
+				<xsl:apply-templates select="archdesc/altformavail
+				| archdesc/*/altformavail"/>
+				<xsl:apply-templates select="archdesc/prefercite
+				| archdesc/*/prefercite"/>
+				<xsl:apply-templates select="archdesc/acqinfo
+				| archdesc/*/acqinfo"/>
+				<xsl:apply-templates select="archdesc/processinfo
+				| archdesc/*/processinfo"/>
+				<xsl:apply-templates select="archdesc/admininfo/appraisal
+				| archdesc/*/appraisal"/>
+				<xsl:apply-templates select="archdesc/admininfo/accruals
+				| archdesc/*/accruals"/>
+			</div>
 		</xsl:if>
 	</xsl:template>
 
@@ -1239,9 +1066,21 @@
 
 
 	<xsl:template match="archdesc/dsc">
-		<xsl:apply-templates/>
+		<div class="archdesc-section dsc">
+			<h3>
+				<xsl:choose>
+					<xsl:when test="dsc/head">
+						<xsl:value-of select="head"/>
+					</xsl:when>
+					<xsl:otherwise>
+						Component Listing
+					</xsl:otherwise>
+				</xsl:choose>
+			</h3>
+			<xsl:apply-templates/>
+		</div>
 	</xsl:template>
-	
+
 	<!--Formats dsc/head and makes it a link target.-->
 	<xsl:template match="dsc/head">
 		<h3>
@@ -1304,7 +1143,7 @@
 					<br/><xsl:value-of select="origination/@label" />
 				</xsl:if>
 				<xsl:apply-templates select="origination"/>
-				<xsl:text>&#x20;</xsl:text>
+				<xsl:text> </xsl:text>
 			</xsl:if>
 
 			<xsl:if test="../phystech">
@@ -1454,9 +1293,9 @@
 		<!-- ****************************************************************** -->
 
 	<xsl:template match="c01">
-		<table class="c01-list">
+		<table class="dcs-components">
 			<tr>
-				<td width="15%"></td>
+				<td class="container-id"></td>
 				<td width="4%"></td>
 				<td width="4%"></td>
 				<td width="4%"></td>


### PR DESCRIPTION
refs [AR-140](https://bugs.dlib.indiana.edu/browse/AR-140)

This set of changes simplifies the formatting of the main finding aid
secetions and adds better structural and semantic markup.

This commit:
* Fixes list formatting for unordered, numbered, and un-bulleted lists
* Simplifies code for selecting default or alternate section headings
* Displays multiple &lt;unitdate&gt; nodes in a comma-separated list
* Adds structural and semantic markup to main content divs
* Moves additional formatting from the XSLT to CSS classes
* Adds structural formatting to controlled access headings
* Narrows the left-most column in the container tree - see [AR-143](https://bugs.dlib.indiana.edu/browse/AR-143) Item 2

