### PR TITLE
Format physfacet in printed finding aids

### DIFF
--- a/app/templates/template.xslt
+++ b/app/templates/template.xslt
@@ -1160,7 +1160,7 @@
 
 
 	    <!-- Adds parens around extent elements except for the first entry in archdesc/did -->
-		<xsl:template match="extent">
+		<xsl:template match="extent | physfacet">
 			<xsl:choose>
 				<xsl:when test="ancestor::did and position() = 1">
 					<xsl:apply-templates/>


### PR DESCRIPTION
refs [AR-140](https://bugs.dlib.indiana.edu/browse/AR-140) Quantity Example 2

This change adds additional formatting to the extents and physfacets in the collection
overview &lt;archdesc/did/physdesc&gt; section of the finding aid.

This commit:
* Wraps any &lt;extent&gt; or &lt;physfacet&gt; after the first in parenthesis

```
    <physdesc altrender="whole">
      <extent altrender="materialtype spaceoccupied">42 interviews</extent>
      <physfacet>Audio files, transcripts, and collateral materials</physfacet>
    </physdesc>
```

<img width="984" alt="Pasted Graphic 2" src="https://user-images.githubusercontent.com/3064318/174890683-177690fe-d807-4fd7-8df9-5a5e8d988566.png">

<img width="974" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/3064318/174890737-8b670664-f394-48aa-a0f9-d8784752601e.png">
