### PR TITLE
Allow apply_templates to take file or directory parameter

### DIFF
--- a/lib/tasks/apply_template.rake
+++ b/lib/tasks/apply_template.rake
@@ -1,9 +1,18 @@
 # frozen_string_literal: true
 
 desc 'Re-apply XSLT template to update HTML versions of finding aids'
+# USAGE:
+#   1. Update all finding aids on the system (default to public/ead)
+#       `bundle exec rake apply_template`
+#   2. Update finding aids for a specific repo (or any directory)
+#        `bundle exec rake apply_template data/atm`
+#   3. Update a single finding aid from a source EAD
+#        `bundle exec rake apply_template public/ead/VAB6923.xml`
+
 task apply_template: :environment do
-  file_path = ARGV.second || "public/ead"
-  file_path = Rails.root.join(file_path) + '**/*.xml' if File.extname(file_path) != ".xml"
+  ARGV.each { |a| task a.to_sym do ; end }
+  options = ARGV[1] || "public/ead"
+  file_path = Rails.root.join(options) + '**/*.xml' if File.extname(options) != ".xml"
   puts "Scanning: #{file_path}\n\n"
   Dir.glob(file_path) do |file|
     puts "Converting: #{file}"


### PR DESCRIPTION
This fixes a bug in passing file or directory names from the
command line.  You can now pass a single filename or a directory
to be scanned for EAD documents to format.

USAGE:
1. Update all finding aids on the system (default to public/ead)
`bundle exec rake apply_template`
2. Update finding aids for a specific repo (or any directory)
`bundle exec rake apply_template data/atm`
3. Update a single finding aid from a source EAD
`bundle exec rake apply_template public/ead/VAB6923.xml`