### PR TITLE
Add larger buttons and collection count of 50 for repository show

### DIFF
--- a/app/assets/stylesheets/arclight.scss
+++ b/app/assets/stylesheets/arclight.scss
@@ -129,3 +129,10 @@ tr.needs-update {
   font-weight: bold;
   background-color: $iu-cream;
 }
+
+// Repository Show page overrides
+.blacklight-repositories-show {
+  .al-repository-collections::after{
+    content: '';
+  }
+}

--- a/app/controllers/arclight/repositories_controller.rb
+++ b/app/controllers/arclight/repositories_controller.rb
@@ -20,7 +20,7 @@ module Arclight
       search_service = Blacklight.repository_class.new(blacklight_config)
       @response = search_service.search(
         q: "level_sim:Collection repository_sim:\"#{@repository.name}\"",
-        rows: 100,
+        rows: 50,
         sort: 'title_sort asc'
       )
       @collections = @response.documents

--- a/app/views/arclight/repositories/show.html.erb
+++ b/app/views/arclight/repositories/show.html.erb
@@ -1,0 +1,47 @@
+<% @page_title = t(:'arclight.views.repositories.show', name: @repository.name) %>
+<%= render 'shared/breadcrumbs' %>
+<%= render @repository %>
+<div class="row al-repository-show-header">
+  <div class="col col-md-8 col-lg-9">
+    <h2 class="h4">
+      <%= t('arclight.views.show.our_collections') %>
+    </h2>
+  </div>
+  <div class="col text-right">
+    <span class="al-repository-collections">
+      <%= link_to(t(:'arclight.views.repositories.view_all_collections', count: collection_count), repository_collections_path(@repository), class: 'btn btn-primary') %>
+    </span>
+  </div>
+</div>
+
+<div class="row">
+  <% @collections.each do |document| %>
+    <div class="col-md-12">
+      <div class='al-document-title-bar'>
+        <div class='row'>
+          <div class='col-md-10 col-lg-9'>
+            <h3 class="h5"><%= link_to document.normalized_title, solr_document_path(document.id) %></h3>
+            <%= content_tag('div', class: 'al-document-abstract-or-scope') do %>
+              <%= content_tag('div', 'data-arclight-truncate' => true) do %>
+                <%= document.abstract_or_scope %>
+              <% end %>
+              <% end if document.abstract_or_scope %>
+            </div>
+            <% if document.unitid %>
+              <div class='col text-right al-collection-id'>
+                <%= t(:'arclight.views.show.collection_id', id: document.unitid) %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+  <div class="row al-repository-show-footer my-3 mt-1">
+
+    <div class="col text-right ">
+      <span class="al-repository-collections">
+        <%= link_to(t(:'arclight.views.repositories.view_all_collections', count: collection_count), repository_collections_path(@repository), class: 'btn btn-primary') %>
+      </span>
+    </div>
+  </div>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -13,3 +13,4 @@ en:
       repositories:
         show: "%{name} - Archives Online at Indiana University"
         title: Repositories - Archives Online at Indiana University
+        view_all_collections: "View all %{count} collections"


### PR DESCRIPTION
The enhances the UX on the repository show page. It will now display up to 50 collections. It also has a larger "View all of our Collections" button at the top and bottom of the collection list.

