### PR TITLE
Handle urls regardless of namespace

### DIFF
--- a/app/templates/template.xslt
+++ b/app/templates/template.xslt
@@ -466,11 +466,11 @@
 			<xsl:when test="text()">
 				<xsl:apply-templates/>
 			</xsl:when>
-			<xsl:when test="@xlink:title">
-				<xsl:value-of select="@xlink:title"/>
+			<xsl:when test="@title | @xlink:title">
+				<xsl:value-of select="@title | @xlink:title"/>
 			</xsl:when>
 			<xsl:otherwise>
-				<xsl:value-of select="@xlink:href"/>
+				<xsl:value-of select="@href | @xlink:href"/>
 			</xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>


### PR DESCRIPTION
In development enviornments, the extptr node still has an associated
namespace, but when running the ingest task, all namespaces are
stripped from the EAD document.

This change allows the proper address link to show up in either
context.

# BEFORE
<img width="970" alt="image" src="https://user-images.githubusercontent.com/3064318/176529848-78436edc-2f6c-4bcc-865a-0f20432350f0.png">

# AFTER
<img width="963" alt="image" src="https://user-images.githubusercontent.com/3064318/176530572-fce207d1-8247-42bc-9594-e6c5bdd139d6.png">
