### PR TITLE
Configure AEON EAD request link

### DIFF
--- a/config/downloads.yml
+++ b/config/downloads.yml
@@ -22,5 +22,5 @@ default:
   printable_view:
     template: '/html/%{eadid}.html'
   ead:
-    template: '/ead/%{eadid}.xml'
+    template: 'https://archives.iu.edu/ead/%{eadid}.xml'
   


### PR DESCRIPTION
Fixes [AR-154](https://bugs.dlib.indiana.edu/browse/AR-154)

Hard-codes the NGAO public host information in the downloads.yml
file.  This solution should work for all environments, but will
always point to the EAD documents that are available on the
production server.

