### PR TITLE
Configure AEON request url via Solr document

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -18,6 +18,10 @@ class SolrDocument
   # Recommendation: Use field names from Dublin Core
   use_extension(Blacklight::Document::DublinCore)
 
+  def root_url
+    "https://archives.iu.edu" # ideally, we'd find a way to look this up from the runnign host
+  end
+
   def campus
     first('campus_unit_ssm')
   end

--- a/config/downloads.yml
+++ b/config/downloads.yml
@@ -22,5 +22,5 @@ default:
   printable_view:
     template: '/html/%{eadid}.html'
   ead:
-    template: '/ead/%{eadid}.xml'
+    template: "%{root_url}/ead/%{eadid}.xml"
   


### PR DESCRIPTION
Fixes [AR-154](https://bugs.dlib.indiana.edu/browse/AR-154)

Add a method to the SolrDocument that returns the request root_url
and then use that in the download template.

The example here hard-codes the host information, but ideally we'd be
able to read it dynamically from the running server configuration.

