### PR TITLE
Provide better defaults for the date range facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -97,7 +97,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'creator_ssim', label: 'Creator', limit: 10
     config.add_facet_field 'creators_ssim', label: 'Creator', show: false
     config.add_facet_field 'component_level_isim', show: false
-    config.add_facet_field 'date_range_sim', label: 'Date Range', range: true
+    config.add_facet_field 'date_range_sim', label: 'Year', range: {assumed_boundaries: [0, Time.now.year + 2]}
     config.add_facet_field 'names_ssim', label: 'Names', limit: 10
     config.add_facet_field 'geogname_sim', label: 'Place', limit: 10
     config.add_facet_field 'places_ssim', label: 'Places', show: false


### PR DESCRIPTION
Fixes [AR-91](https://bugs.dlib.indiana.edu/browse/AR-91)

ROOT CAUSE:
Traject is mis-interpreting some dates from EADs and there are a
variety of future dates in the index that are causing the range-limit
gem to fail at autodetecting the correct boundaries.

This change adds default boundaries of Year 0 (CE) to two years in
the future.  It also changes the name of the facet.

To fix the underlying problem, we would need to investigate which items
traject is indexin with future dated years (4xxx, 8xxx, 28xx, etc.)
You can see the indexed terms by viewing the Solr schema live:
http://localhost:8983/solr/#/blacklight-core/schema?field=date_range_sim
If you show all terms (i.e. enter 10000 in the box next to Top-Terms,
the bottom of the list will display the anomalous values which can
be clicked on to identify which documents they're assoiciated with.

# BEFORE
<img width="274" alt="image" src="https://user-images.githubusercontent.com/3064318/176596314-5df962b5-c183-440c-a421-b9246f0891a9.png">

# AFTER
<img width="269" alt="image" src="https://user-images.githubusercontent.com/3064318/176596363-1cd2240a-29f5-4a91-a025-a7c885f26bb6.png">


### Strange dates indexed into solr
<img width="1057" alt="image" src="https://user-images.githubusercontent.com/3064318/176596164-17f46040-8ecf-443f-8bb1-a40503b1d0d1.png">
