### PR TITLE
Suppress empty Component Inventory lists

### DIFF
--- a/app/templates/template.xslt
+++ b/app/templates/template.xslt
@@ -62,7 +62,7 @@
 					<xsl:call-template name="archdesc-admininfo"/>
 					<xsl:apply-templates select="archdesc/fileplan | archdesc/*/fileplan"/>
 					<xsl:apply-templates select="archdesc/bibliography"/>
-					<xsl:apply-templates select="archdesc/dsc"/>
+					<xsl:apply-templates select="archdesc/dsc[count(*)>0]"/>
 					<xsl:apply-templates select="archdesc/index | archdesc/*/index"/>
 				</div>
 			</body>


### PR DESCRIPTION
ISSUE
ArcLight EADs include an empty <dsc/> node even when there are
no containers associated with the collection.

Previously this was causing the printed finding aids to include
the section heading with no following content.  This change
suppresses the entire secion when there are no child nodes below
/arcdesc/dsc

Example collection VAE2705 [EAD](https://archives.iu.edu/ead/VAE2705.xml)

# BEFORE
<img width="1165" alt="image" src="https://user-images.githubusercontent.com/3064318/176752804-3b7e6340-7c6e-408a-9132-f0fe530d682e.png">

# AFTER
<img width="1165" alt="image" src="https://user-images.githubusercontent.com/3064318/176752938-3aa2a064-59a5-4668-b260-7450a2ab5f68.png">
