### PR TITLE
Adds expand function to components title. Adds more details

### DIFF
--- a/app/assets/stylesheets/arclight.scss
+++ b/app/assets/stylesheets/arclight.scss
@@ -136,3 +136,26 @@ tr.needs-update {
     content: '';
   }
 }
+
+// Container show page overrides
+.al-toggle-children-container{
+  margin-left: 0;
+}
+
+.al-toggle-view-children:not(.collapsed)::before {
+  content: image-url('blacklight/minus.svg');
+  position: relative;
+  top: 6px;
+}
+.al-toggle-view-children::before {
+  content: image-url('blacklight/plus.svg');
+  position: relative;
+  top: 6px;
+}
+
+.al-toggle-view-children:not(.collapsed)::after {
+  content: none;
+}
+.al-toggle-view-children::after {
+  content: none;
+}

--- a/app/views/catalog/_index_collection_context_default.html.erb
+++ b/app/views/catalog/_index_collection_context_default.html.erb
@@ -3,38 +3,51 @@
 <li id="<%= document.id %>" class="al-collection-context row d-flex align-items-start">
   <div class="documentHeader row" data-document-id="<%= document.id %>">
     <% requestable = item_requestable?('', { document: document }) %>
-    <% if document.children? %>
-      <div class="al-toggle-children-container">
-        <%= link_to(
-          '',
-          "##{document.id}-collapsible-hierarchy",
-          class: "al-toggle-view-children #{!show_expanded?(document) ? 'collapsed' : ''}",
-          'aria-label': t('arclight.hierarchy.view_all'),
-            data: {
-              toggle: 'collapse'
-            }
-          )
-        %>
-      </div>
-    <% end %>
     <%# REMOVE ICON FROM COLLECTION CONTEXT %>    
     <div class="col col-no-left-padding d-flex flex-wrap">
       <div class="index_title document-title-heading my-w-75 w-md-100 order-0">
-        <% if document.level == "Series" %> 
-          <span class="text-nowrap text-muted">Series:</span>
-        <% end %>
-        <% if document.level == "Subseries" %> 
-          <span class="text-nowrap text-muted">Subseries:</span>
-        <% end %>
-        <% counter = document_counter_with_offset(document_counter) %>
-        <%= link_to_document document, document_show_link_field(document), counter: counter %>
+        <div class="al-toggle-children-container">
         <% if document.children? %>
-          <span class="badge badge-pill badge-secondary al-number-of-children-badge"><%= document.number_of_children %><span class="sr-only"><%= t(:'arclight.views.index.number_of_components', count: document.number_of_children) %></span></span>
-        <% end %>
+          
+            <%= link_to(
+          "##{document.id}-collapsible-hierarchy",
+          class: "al-toggle-view-children #{!show_expanded?(document) ? 'collapsed' : ''}",
+          'aria-label': "Toggle children",
+            data: {
+              toggle: 'collapse'
+            }
+          ) do
+        %>
+
+              <% if document.level == "Series" %>
+                <span class="text-nowrap text-muted">Series:</span>
+              <% end %>
+              <% if document.level == "Subseries" %>
+                <span class="text-nowrap text-muted">Subseries:</span>
+              <% end %>
+              <% counter = document_counter_with_offset(document_counter) %>
+              <%=  document.normalized_title  %>
+              <span class="badge badge-pill badge-secondary al-number-of-children-badge">
+                <%= document.number_of_children %>
+                <span class="sr-only"><%= t(:'arclight.views.index.number_of_components', count: document.number_of_children) %></span>
+              </span>
+            <% end %>
+          <% else %>
+            <% if document.level == "Series" %>
+              <span class="text-nowrap text-muted">Series:</span>
+            <% end %>
+            <% if document.level == "Subseries" %>
+              <span class="text-nowrap text-muted">Subseries:</span>
+            <% end %>
+            <%=  document.normalized_title  %>
+          <% end %>
+
+          <%= link_to  "more details", document, class: "small", 'aria-label':  "more details about #{document.normalized_title}" %>
+        </div>
       </div>
       
       <div class="my-w-25 w-md-100 order-12 order-md-1">
-        <%= render_index_doc_actions document, wrapping_class: 'd-flex justify-content-end' %>
+        <%= render_index_doc_actions document, wrapping_class: 'd-flex justify-content-end text-right' %>
       </div>
 
       <div class="order-2">


### PR DESCRIPTION
ref [AR-171](https://bugs.dlib.indiana.edu/browse/AR-171) Expand All Contents

This change makes expand/collapse of children in the content tree easier to understand.

- Add a “More details” target to display the specific item context (i.e. duplicates the function of clicking on an item title right now)

- Make both the “+/-” and title part of the same clickable area to expand or collapse the children below

### Before
![screencapture-ngao-qa-curationexperts-catalog-InU-Ar-VAA2780aspace-a00ad0c99f15cfb21c2e086d39f0f46d-2022-07-01-16_54_29](https://user-images.githubusercontent.com/8102/176972237-bff03432-2eed-47b1-bde1-9e7fe9a2a167.png)


### After

![screencapture-localhost-3000-catalog-InU-Ar-VAA2780aspace-a00ad0c99f15cfb21c2e086d39f0f46d-2022-07-01-16_54_11](https://user-images.githubusercontent.com/8102/176972244-adc8ab6b-ecd2-4c14-9f22-5c2b35cb6764.png)


