### PR TITLE
Update Solr config and schema to support integer date ranges

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -97,6 +97,8 @@
     <fieldType name="pfloat" class="solr.FloatPointField" docValues="true"/>
     <fieldType name="plong" class="solr.LongPointField" docValues="true"/>
     <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>
+    <!-- trie numeric field type for faster range queries -->
+    <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" positionIncrementGap="0"/>
 
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
          is a more restricted form of the canonical representation of dateTime
@@ -316,6 +318,7 @@
    <dynamicField name="*_ssim"  type="string"    stored="true"  indexed="true"  multiValued="true"  />
    <dynamicField name="*_isim"  type="pint"      stored="true"  indexed="true"  multiValued="true"  />
    <dynamicField name="*_ii"    type="pint"      stored="false" indexed="true"  multiValued="false" />
+   <dynamicField name="*_iim"   type="tint"      stored="false" indexed="true"  multiValued="true" />
  </fields>
 
  <!-- Field to use to determine and enforce document uniqueness.

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -174,6 +174,7 @@
        <str name="facet.field">level_sim</str>
        <str name="facet.field">creator_sim</str>
        <str name="facet.field">date_range_sim</str>
+       <str name="facet.field">date_range_iim</str>
        <str name="facet.field">names_sim</str>
        <str name="facet.field">geogname_sim</str>
        <str name="facet.field">access_subjects_sim</str>


### PR DESCRIPTION
Refs [AR-91](https://bugs.dlib.indiana.edu/browse/AR-91)

# Summary 
The blacklight range-limit gem requires an integer data field instead of a string field.

see https://github.com/projectblacklight/blacklight_range_limit#requirements

This change adds the necessary field-type, dynamic-field configuration,
and facet setup to Solr to support an integer-based date range.

# Deployment
This change leaves the existing string-based date range definitions in place
so it is backward compatible with existing code releases.
