### PR TITLE
Index Years as integers instead of strings

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -107,12 +107,12 @@ class CatalogController < ApplicationController
     config.add_facet_field 'creator_ssim', label: 'Creator', limit: 10
     config.add_facet_field 'creators_ssim', label: 'Creator', show: false
     config.add_facet_field 'component_level_isim', show: false
-    config.add_facet_field 'date_range_sim', label: 'Year', range: {assumed_boundaries: [0, Time.now.year + 2]}
     config.add_facet_field 'names_ssim', label: 'Names', limit: 10
     config.add_facet_field 'geogname_sim', label: 'Place', limit: 10
     config.add_facet_field 'places_ssim', label: 'Places', show: false
     config.add_facet_field 'access_subjects_ssim', label: 'Subject', limit: 10
     config.add_facet_field 'parent_ssim', show: false
+    config.add_facet_field 'date_range_iim', label: 'Year', range: {assumed_boundaries: [0, Time.now.year + 2]}
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/lib/ngao/traject/ead2_config.rb
+++ b/lib/ngao/traject/ead2_config.rb
@@ -271,7 +271,7 @@ to_field 'dimensions_teim', extract_xpath('/ead/archdesc/did/physdesc/dimensions
 to_field 'genreform_sim', extract_xpath('/ead/archdesc/controlaccess/genreform')
 to_field 'genreform_ssm', extract_xpath('/ead/archdesc/controlaccess/genreform')
 
-to_field 'date_range_sim', extract_xpath('/ead/archdesc/did/unitdate/@normal', to_text: false) do |_record, accumulator|
+to_field 'date_range_iim', extract_xpath('/ead/archdesc/did/unitdate/@normal', to_text: false) do |_record, accumulator|
   range = Ngao::YearRange.new
   next range.years if accumulator.blank?
 
@@ -587,7 +587,7 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
     end
   end
 
-  to_field 'date_range_sim', extract_xpath('./did/unitdate/@normal', to_text: false) do |_record, accumulator|
+  to_field 'date_range_iim', extract_xpath('./did/unitdate/@normal', to_text: false) do |_record, accumulator|
     range = Ngao::YearRange.new
     next range.years if accumulator.blank?
 

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -97,6 +97,8 @@
     <fieldType name="pfloat" class="solr.FloatPointField" docValues="true"/>
     <fieldType name="plong" class="solr.LongPointField" docValues="true"/>
     <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>
+    <!-- trie numeric field type for faster range queries -->
+    <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" positionIncrementGap="0"/>
 
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
          is a more restricted form of the canonical representation of dateTime
@@ -316,6 +318,7 @@
    <dynamicField name="*_ssim"  type="string"    stored="true"  indexed="true"  multiValued="true"  />
    <dynamicField name="*_isim"  type="pint"      stored="true"  indexed="true"  multiValued="true"  />
    <dynamicField name="*_ii"    type="pint"      stored="false" indexed="true"  multiValued="false" />
+   <dynamicField name="*_iim"   type="tint"      stored="false" indexed="true"  multiValued="true" />
  </fields>
 
  <!-- Field to use to determine and enforce document uniqueness.

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -174,6 +174,7 @@
        <str name="facet.field">level_sim</str>
        <str name="facet.field">creator_sim</str>
        <str name="facet.field">date_range_sim</str>
+       <str name="facet.field">date_range_iim</str>
        <str name="facet.field">names_sim</str>
        <str name="facet.field">geogname_sim</str>
        <str name="facet.field">access_subjects_sim</str>


### PR DESCRIPTION
Fixes [AR-91](https://bugs.dlib.indiana.edu/browse/AR-91)

# Summary 
These changes allow the year range data for the date range facet to be sorted numerically (202 < 2010) rather than lexically (202 > 2010).  This will result in the date range slider behaving in a much more predictable manner.

# WARNING: Side Effects
This PR updates the solr schema, solr config, and catalog controller.  CircleCI will be broken until a new Solr image has been created that contains the corresponding changes in the `myconfig` configuration set directory.

# WARNING: Deployment
This code requires the solr schema changes to be implement before deployment.  The solr changes have also been submitted separately as a backward compatible PR that can be merged and deployed before this PR.  See https://github.com/IUBLibTech/ngao/pull/268

