### PR TITLE
Ar 124 help link fix

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -60,4 +60,5 @@
     </div>
   </div>
 <% end %>
-<%= link_to 'Get search help', help_path, class: 'help-link text-right' %>
+<div class="d-flex justify-content-end col"><%= link_to 'Get search help', help_path, class: 'pt-2 text-right' %></div>
+


### PR DESCRIPTION
Fixes #AR-124 Help-Link previously extended across the whole nav bar. This fix refactors the markup to only be clickable on the text.
