### PR TITLE
Add headings for container extents and dimensions

### DIFF
--- a/app/templates/template.xslt
+++ b/app/templates/template.xslt
@@ -959,11 +959,31 @@
 		</p>
 	</xsl:template>
 
-	<xsl:template match="dsc//did/physdesc">
+	<xsl:template match="dsc//did/physdesc[not(child::dimensions or child::extent)]">
 		<p>
 			<span class="label">
 				<xsl:value-of select="@type"/>
 				<xsl:text>Physical Description: </xsl:text>
+			</span>
+			<xsl:apply-templates/>
+		</p>
+	</xsl:template>
+
+	<xsl:template match="did/physdesc/dimensions">
+		<p>
+			<span class="label">
+				<xsl:value-of select="@type"/>
+				<xsl:text>Dimensions: </xsl:text>
+			</span>
+			<xsl:apply-templates select="node()"/>
+		</p>
+	</xsl:template>
+
+	<xsl:template match="did/physdesc/extent">
+		<p>
+			<span class="label">
+				<xsl:value-of select="@type"/>
+				<xsl:text>Quantity: </xsl:text>
 			</span>
 			<xsl:apply-templates select="node()"/>
 		</p>


### PR DESCRIPTION
Refs [AR-143](https://bugs.dlib.indiana.edu/browse/AR-143)

# Summary 
Provide labels for container-level physdesc/extent and physdesc/dimentions.  See https://archives.iu.edu/ead/InU-Li-VAA1392.xml for representative XML.

# Screenshot Before
<img width="800" alt="image-2022-07-06-21-50-42-916" src="https://user-images.githubusercontent.com/3064318/177681664-95ccb09b-55c0-43aa-806d-f286a6dd9acd.png">

# Screenshot After
<img width="800" alt="image-2022-07-06-21-48-59-218" src="https://user-images.githubusercontent.com/3064318/177681701-b28e6213-56cc-4b81-b445-46f59a14242c.png">
