### PR TITLE
Add layout fixes for Firefox

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -49,6 +49,7 @@ div.did {
 }
 
 table {
+  table-layout: fixed; // fix to prevent firefox from trying to distribute columns evenly
   width: 95%;
   margin-left: auto;
   margin-right: auto;
@@ -78,7 +79,7 @@ table.overview {
   td.did-label {
     font-weight: bold;
     vertical-align: text-top;
-    width: 8rem;
+    width: 8.5rem;
   }
 
   td.did-value {
@@ -173,7 +174,7 @@ div.component {
 
   p, ol, ul {
     margin-block-start: 0.25rem;
-    margin-block-end: 0.5rem;
+    margin-block-end: 0.25rem;
   }
 
   .label {
@@ -198,6 +199,7 @@ div.component {
   div.component-info{
     border-top: 1.25pt solid dimgrey;
     padding-top: 4pt;
+    padding-left: 4pt;
     margin-bottom: 6pt;
     width: 100%;
 
@@ -216,12 +218,13 @@ div.component {
   }
 
   .unittitle {
+    display: inline;
     font-family: GeorgiaProBold, Georgia, "Times New Roman", Times, serif;
-    margin-bottom: 4pt;
+    margin-bottom: 6pt;
   }
 }
 
-.c01 .unittitle, .c02 .unittitle {
+.unittitle.series, .unittitle.subseries {
   font-size: 115%;
   font-weight: bold;
 }

--- a/app/templates/template.xslt
+++ b/app/templates/template.xslt
@@ -929,10 +929,10 @@
 	</xsl:template>
 
 	<xsl:template match="dsc//did">
-		<h4 class="label">
-			<xsl:apply-templates select="../@level"/>
-		</h4>
-		<div class="unittitle">
+		<xsl:apply-templates select="../@level"/>
+		<div>
+			<xsl:attribute name="class">unittitle <xsl:value-of select="../@level"/>
+			</xsl:attribute>
 			<xsl:apply-templates select="unittitle"/>
 			<xsl:apply-templates select="unitdate[1]"/>
 		</div>
@@ -982,10 +982,14 @@
 	<xsl:template match="attribute::level">
 		<xsl:choose>
 			<xsl:when test="../@level='series'">
-				Series:
+				<h4 class="label">
+					Series:
+				</h4>
 			</xsl:when>
 			<xsl:when test="../@level='subseries'">
-				Subseries:
+				<h4 class="label">
+					Subseries:
+				</h4>
 			</xsl:when>
 		</xsl:choose>
 	</xsl:template>


### PR DESCRIPTION
Firefox renders a few components differently than Chrome or Safari.

This commit attempts to address some of those differences without
negatively impacting display in the other two browsers:

* Add explicit table-layout to prevent Firefox from evenly distributing column widths
* Tighten up spacing between containers
* Handle empty <label> elements that firefox allocates margins and padding for

# Before
<img width="817" alt="image" src="https://user-images.githubusercontent.com/3064318/177687655-bdce846f-f55c-4c84-abd3-cfaf2b20843f.png">
<img width="822" alt="image" src="https://user-images.githubusercontent.com/3064318/177687738-d3bea79f-df43-458f-8a88-8fa039d163a1.png">

# After
<img width="821" alt="image" src="https://user-images.githubusercontent.com/3064318/177688002-bd4d8925-4acc-4808-9ed9-70061b2c13f9.png">
<img width="818" alt="image" src="https://user-images.githubusercontent.com/3064318/177688109-9009af13-d794-443e-9955-315c6b1bdc88.png">
