### PR TITLE
Context show/hide with item count

### DIFF
--- a/app/assets/images/blacklight/collapse.svg
+++ b/app/assets/images/blacklight/collapse.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrows-collapse" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M1 8a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 8zm7-8a.5.5 0 0 1 .5.5v3.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 1 1 .708-.708L7.5 4.293V.5A.5.5 0 0 1 8 0zm-.5 11.707-1.146 1.147a.5.5 0 0 1-.708-.708l2-2a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1-.708.708L8.5 11.707V15.5a.5.5 0 0 1-1 0v-3.793z"/>
+</svg>

--- a/app/assets/images/blacklight/expand.svg
+++ b/app/assets/images/blacklight/expand.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrows-expand" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M1 8a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13A.5.5 0 0 1 1 8zM7.646.146a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1-.708.708L8.5 1.707V5.5a.5.5 0 0 1-1 0V1.707L6.354 2.854a.5.5 0 1 1-.708-.708l2-2zM8 10a.5.5 0 0 1 .5.5v3.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 0 1 .708-.708L7.5 14.293V10.5A.5.5 0 0 1 8 10z"></path>
+</svg>

--- a/app/assets/javascripts/context_navigation.js.erb
+++ b/app/assets/javascripts/context_navigation.js.erb
@@ -34,8 +34,8 @@ class ExpandButton {
    * @return {jQuery} - a jQuery object containing the targeted <li>
    */
   findSiblings() {
-    const $siblings = this.$el.parent().children('li');
-    return $siblings.slice(0, -1);
+    const $siblings = this.$el.parent().siblings('li');
+    return $siblings;
   }
 
   /**
@@ -51,20 +51,31 @@ class ExpandButton {
     this.$el.toggleClass('collapsed');
 
     const containerText = this.$el.hasClass('collapsed') ? this.collapseText : this.expandText;
-    this.$el.text(containerText);
+    this.$el.html(containerText);
+    // Update count on click
+    const alCount = this.findSiblings().length;
+    this.$el.find( ".al-count" ).text(alCount);
   }
 
   /**
    * @constructor
    */
   constructor(data) {
-    this.collapseText = data.collapse;
-    this.expandText = data.expand;
+    var collapseIcon = `<img alt='collapse' src='<%= image_path('blacklight/collapse.svg') %>'>`;
+    var expandIcon = `<img alt='expand' src='<%= image_path('blacklight/expand.svg') %>'>`;
+    
+    // Find Siblings count
+    var siblingCount =   `&nbsp;<span class='al-count'>999</span>&nbsp;`;
 
-    this.$el = $(`<button class="my-3 btn btn-secondary btn-sm">${this.expandText}</button>`);
+    this.collapseText =  collapseIcon + `Hide`+ siblingCount  + data.collapse;
+    this.expandText =  expandIcon + `Show` + siblingCount + data.expand;
+
+    
+    this.$el = $(`<button class="btn btn-link btn-sm">${this.expandText}</button>`);
     this.handleClick = this.handleClick.bind(this);
     this.$el.click(this.handleClick);
   }
+  
 }
 
 /**
@@ -76,13 +87,13 @@ class NestedExpandButton extends ExpandButton {
   /**
    * This retrieves the <li> elements which are hidden/rendered in response to
    *   clicking the <button> element
-   * @param {jQuery} $li - the <button> element
+   * @param {jQuery} $span - the <button> element
    * @return {jQuery} - a jQuery object containing the targeted <li>
    */
   findSiblings() {
     const highlighted = this.$el.siblings('.al-hierarchy-highlight');
     const $siblings = highlighted.prevAll('.al-collection-context');
-    return $siblings.slice(0, -1);
+    return $siblings;
   }
 }
 
@@ -100,8 +111,7 @@ class Placeholder {
   buildElement() {
     // CHANGED PLACEHOLDER ELEMENT
     const elementMarkup = '<div class="al-hierarchy-placeholder">' +
-      '<h3 class="col-md-9"> <img alt="loading icon" src="<%= image_path('ajax-loader.gif') %>"> Loading...</h3>' +
-      '</div>';
+      `<h5 class="col-md-9"> <img alt="loading icon" src="<%= image_path('ajax-loader.gif') %>"> Loading...</h5></div>`;
     return $(elementMarkup);
   }
   /* eslint-enable class-methods-use-this */
@@ -173,8 +183,15 @@ class ContextNavigation {
     const $ul = $('<ul></ul>');
     $ul.addClass('pl-0');
     $ul.addClass('prev-siblings');
+
+    const $span = $('<span></span>');
+    $span.addClass('divider');
+    $span.attr('text-position', 'left');
+    $ul.append($span);
+
     const button = new ExpandButton(this.data);
-    $ul.append(button.$el);
+    $span.append(button.$el);
+  
     return $ul;
   }
 
@@ -193,7 +210,7 @@ class ContextNavigation {
     let nextSiblingDocs = [];
 
     if (prevSiblingDocs.length > 1 && originalDocumentIndex > 0) {
-      const hiddenPrevSiblingDocs = prevSiblingDocs.slice(0, -1);
+      const hiddenPrevSiblingDocs = prevSiblingDocs;
       hiddenPrevSiblingDocs.forEach(siblingDoc => {
         siblingDoc.collapse();
       });
@@ -214,6 +231,7 @@ class ContextNavigation {
     // Insert the rendered sibling documents before the <li> elements
     this.ul.append(renderedNextSiblingItems);
     this.el.html(this.ul);
+
   }
 
   /**
@@ -246,7 +264,11 @@ class ContextNavigation {
       });
       renderedBeforeDocs = beforeDocs.map(newDoc => newDoc.render()).join('');
       prevParentList = this.buildExpandList();
+
+
       prevParentList.append(renderedBeforeDocs);
+
+      
     } else {
       renderedBeforeDocs = beforeDocs.map(newDoc => newDoc.render()).join('');
     }
@@ -254,6 +276,7 @@ class ContextNavigation {
     // Silly but works for now
     this.ul.append(prevParentList || renderedBeforeDocs);
 
+  
     let itemDoc = newDocs.slice(newDocIndex, newDocIndex + 1);
     let renderedItemDoc = itemDoc.map(doc => doc.render()).join('');
 
@@ -289,12 +312,12 @@ class ContextNavigation {
   updateListSiblings($li) {
     const prevSiblings = $li.prevAll('.al-collection-context');
     if (prevSiblings.length > 1) {
-      const hiddenNextSiblings = prevSiblings.slice(0, -1);
+      const hiddenNextSiblings = prevSiblings;
       hiddenNextSiblings.toggleClass('collapsed');
 
       const button = new NestedExpandButton();
 
-      const lastHiddenNextSibling = hiddenNextSiblings[hiddenNextSiblings.length - 1];
+      const lastHiddenNextSibling = hiddenNextSiblings[hiddenNextSiblings.length];
       button.$el.insertAfter(lastHiddenNextSibling);
     }
   }
@@ -336,6 +359,7 @@ class ContextNavigation {
     this.el.parent().data('resolved', true);
     this.addListenersForPlusMinus();
     this.enablebuttons();
+    this.showSiblingCount();
     Blacklight.doBookmarkToggleBehavior();
     this.el.trigger('navigation.contains.elements');
   }
@@ -346,7 +370,12 @@ class ContextNavigation {
     var srOnly = $('h2[data-sr-enable-me]');
     toEnable.removeClass('disabled');
     toEnable.text(srOnly.data('hasContents'));
-    srOnly.text(srOnly.data('hasContents'));
+    srOnly.text(srOnly.data('hasContents'));  
+  }
+
+  showSiblingCount(){
+    var alCount = this.el.find('.prev-siblings').children('li').length;
+    this.el.find( ".al-count" ).text(alCount);
   }
 
   addListenersForPlusMinus() {
@@ -380,4 +409,5 @@ Blacklight.onLoad(function () {
       );
     contextNavigation.getData();
   });
+ 
 });

--- a/app/assets/stylesheets/arclight.scss
+++ b/app/assets/stylesheets/arclight.scss
@@ -66,14 +66,14 @@ body {
     border: 1px solid transparent;
     border-width: 2px;
     border-radius: 20px;
-    padding: .5625em 1em;
+    padding: 0.5625em 1em;
     margin: 0 0 1rem;
     font-size: 1rem;
     background-color: #900;
     color: #fff;
-    font-family: BentonSansBold,Helvetica,Arial,sans-serif;
+    font-family: BentonSansBold, Helvetica, Arial, sans-serif;
     font-weight: 400;
-    transition: background-color .2s ease-out,color .2s ease-out,border-color .18s ease-out;
+    transition: background-color 0.2s ease-out, color 0.2s ease-out, border-color 0.18s ease-out;
   }
 }
 
@@ -103,7 +103,7 @@ h2.repository-header {
   display: none;
   text-decoration: none;
   color: #ffffff;
-  background-color: rgba(153, 0, 0, .7);
+  background-color: rgba(153, 0, 0, 0.7);
   padding: 10px 20px 10px 10px;
   font-size: 12px;
 }
@@ -119,7 +119,7 @@ h2.repository-header {
   margin-bottom: 1rem;
 
   h3 {
-    padding-top: .5rem;
+    padding-top: 0.5rem;
     padding-bottom: 3rem;
   }
 }
@@ -130,25 +130,65 @@ tr.needs-update {
   background-color: $iu-cream;
 }
 
+// Divider for Collections
+.divider {
+  display: flex;
+  align-items: center;
+  padding: 0;
+  cursor: pointer;
+  white-space: nowrap;
+  .btn {
+    display: flex;
+    align-items: center;
+
+    color: #4a3c31;
+    padding-left: 0;
+    img {
+      margin-right: 0.5rem;
+    }
+  }
+}
+
+.divider:before,
+.divider:after {
+  content: "";
+  flex: 0 1 100%;
+  border-bottom: 1px solid rgba(74, 60, 49, 0.3);
+  margin: 0 1rem;
+}
+
+.divider:before {
+  margin-left: 0;
+}
+
+.divider:after {
+  margin-right: 0;
+}
+
+.divider[text-position="right"]:after,
+.divider[text-position="left"]:before {
+  content: none;
+}
+
 // Repository Show page overrides
 .blacklight-repositories-show {
-  .al-repository-collections::after{
-    content: '';
+  .al-repository-collections::after {
+    content: "";
   }
 }
 
 // Container show page overrides
-.al-toggle-children-container{
+.al-toggle-children-container {
   margin-left: 0;
 }
 
 .al-toggle-view-children:not(.collapsed)::before {
-  content: image-url('blacklight/minus.svg');
+  content: image-url("blacklight/minus.svg");
   position: relative;
   top: 6px;
 }
 .al-toggle-view-children::before {
-  content: image-url('blacklight/plus.svg');
+  content: image-url("blacklight/plus.svg");
   position: relative;
   top: 6px;
 }
@@ -158,4 +198,26 @@ tr.needs-update {
 }
 .al-toggle-view-children::after {
   content: none;
+}
+
+.al-hierarchy-highlight {
+  > .documentMetadata,
+  > .documentHeader {
+   background: #FDF7E7;
+   padding: 0 1rem;
+ }
+ > .documentHeader {
+  padding-top: 1rem;
+}
+}
+li.al-collection-context {
+  .documentHeader {
+    margin-bottom: 0 !important;
+    padding-bottom: 1rem;
+  }
+  .documentMetadata {
+    flex-grow: 1;
+    margin-bottom: 1rem;
+    width: 100%;
+  }
 }

--- a/app/views/catalog/_index_collection_context_default.html.erb
+++ b/app/views/catalog/_index_collection_context_default.html.erb
@@ -1,14 +1,14 @@
-
 <%# COPIED FROM ARCLIGHT TO REMOVE ICON FROM COLLECTION CONTEXT %>
+
 <li id="<%= document.id %>" class="al-collection-context row d-flex align-items-start">
   <div class="documentHeader row" data-document-id="<%= document.id %>">
     <% requestable = item_requestable?('', { document: document }) %>
-    <%# REMOVE ICON FROM COLLECTION CONTEXT %>    
+    <%# REMOVE ICON FROM COLLECTION CONTEXT %>
     <div class="col col-no-left-padding d-flex flex-wrap">
       <div class="index_title document-title-heading my-w-75 w-md-100 order-0">
         <div class="al-toggle-children-container">
-        <% if document.children? %>
-          
+          <% if document.children? %>
+
             <%= link_to(
           "##{document.id}-collapsible-hierarchy",
           class: "al-toggle-view-children #{!show_expanded?(document) ? 'collapsed' : ''}",
@@ -42,20 +42,20 @@
             <%=  document.normalized_title  %>
           <% end %>
 
-          <%= link_to  "more details", document, class: "small", 'aria-label':  "more details about #{document.normalized_title}" %>
+          <%= link_to "more details", document, class: "small", 'aria-label':  "more details about #{document.normalized_title}" %>
         </div>
       </div>
-      
+      <% unless original_document?(document) %>
       <div class="my-w-25 w-md-100 order-12 order-md-1">
         <%= render_index_doc_actions document, wrapping_class: 'd-flex justify-content-end text-right' %>
       </div>
-
-      <div class="order-2">
-        <div class="row">
-          <%= content_tag('div', class: 'al-document-abstract-or-scope mb-0') do %>
-            <%= content_tag('div', data: { 'arclight-truncate': true, 'truncate-more': I18n.t('arclight.truncation.view_more'), 'truncate-less': I18n.t('arclight.truncation.view_less') } ) do %>
-              <%= document.abstract_or_scope %>
-            <% end %>
+    <% end %>
+    <div class="order-2">
+      <div class="row">
+        <%= content_tag('div', class: 'al-document-abstract-or-scope mb-0') do %>
+          <%= content_tag('div', data: { 'arclight-truncate': true, 'truncate-more': I18n.t('arclight.truncation.view_more'), 'truncate-less': I18n.t('arclight.truncation.view_less') } ) do %>
+            <%= document.abstract_or_scope %>
+          <% end %>
           <% end if document.abstract_or_scope %>
         </div>
       </div>
@@ -69,4 +69,5 @@
       <%= generic_context_navigation(document, component_level: document.component_level + 1, original_parents: params[:original_parents]) %>
     <% end %>
   <% end %>
-</li>
+
+</li></li>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -14,3 +14,6 @@ en:
         show: "%{name} - Archives Online at Indiana University"
         title: Repositories - Archives Online at Indiana University
         view_all_collections: "View all %{count} collections"
+      show:
+        expand: "items above"
+        collapse: "items below"


### PR DESCRIPTION
Refs [AR-171](https://bugs.dlib.indiana.edu/browse/AR-171)

# Summary
Show and hide siblings' with more context and meaning. The button is now included in the hierarchy with stronger visual clue as to its position. There is now a count with language that represents the information that is being hidden or shown.

# Screenshot before
![before@1x](https://user-images.githubusercontent.com/8102/178355107-e6d5e175-d354-46bf-9eba-b69a13b6b21d.png)

# Screenshot After
![after@1x](https://user-images.githubusercontent.com/8102/178355090-5b961032-a622-4274-95be-63d686c4393f.png)


