### PR TITLE
Display all fields when showing collection context

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -14,4 +14,15 @@ class SearchBuilder < Blacklight::SearchBuilder
   #   def add_custom_data_to_query(solr_parameters)
   #     solr_parameters[:custom] = blacklight_params[:user_value]
   #   end
+
+  self.default_processor_chain += [:return_all_fields_in_collection_context]
+
+  ##
+  # For the collection_context views, return all stored fields
+  def return_all_fields_in_collection_context(solr_params)
+    if %w[collection_context].include? blacklight_params[:view]
+      solr_params[:fl] = '*'
+    end
+    solr_params
+  end
 end


### PR DESCRIPTION
The collection context queries previously only displayed
the default fields configured in solrconf.xml.  This change
requests all fields (only) when displaying the collection_context
view.