### PR TITLE
Add Component Identifier (unitid) to metadata display

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -333,6 +333,7 @@ class CatalogController < ApplicationController
     }, if: lambda { |_context, _field_config, document|
       document.containers.present?
     }
+    config.add_component_field 'unitid_ssm', label: 'Component Identifier', helper_method: :render_html_tags
     config.add_component_field 'abstract_ssm', label: 'Abstract', helper_method: :render_html_tags
     config.add_component_field 'extent_ssm', label: 'Extent'
     config.add_component_field 'scopecontent_tesim', label: 'Scope and Content', helper_method: :render_html_tags


### PR DESCRIPTION
Fixes [AR-177](https://bugs.dlib.indiana.edu/browse/AR-177)

# Summary 
Displays the unitid with the label "Component Identifier"

# Screenshot before
<img width="800" alt="image" src="https://user-images.githubusercontent.com/3064318/178628626-d5434964-66f7-4c7f-820e-54062dbe3d61.png">

# Screenshot after
<img width="1128" alt="image" src="https://user-images.githubusercontent.com/3064318/178628921-ad1c3872-56e5-454c-a077-f89cc69594bb.png">

# Other notes
This change makes the unitid available to any partial that displays container-level metadata and gives it the label "Component Identifier".  By adding this to the catalog config, any partial that displays the configured metadata should automatically pick this up.  Similarly, if this block of description is moved to display within the collection hierarchy, this change will follow it.