### PR TITLE
Still having sqlite problems, updates to 1.4.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -397,7 +397,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.3)
+    sqlite3 (1.4.4)
     sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)


### PR DESCRIPTION
After fixing build problems with sqlite in #289, we still had the same compile problem on servers where the Rails code is run natively for job processing.  Seems to have been a widespread problem in 1.4.3 that was fixed in 1.4.4, which this PR bumps up to.