### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build and push to Docker Hub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: iublibtech/archives_online
         username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/dockerimage_stable.yml
+++ b/.github/workflows/dockerimage_stable.yml
@@ -17,7 +17,7 @@ jobs:
       id: get_branch
       run: echo "BRANCH_NAME=$(echo ${GITHUB_REF:11})" >> $GITHUB_ENV
     - name: Build and push stable to Docker Hub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: iublibtech/archives_online
         username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/dockerimage_test.yml
+++ b/.github/workflows/dockerimage_test.yml
@@ -17,7 +17,7 @@ jobs:
       id: get_branch
       run: echo "BRANCH_NAME=$(echo ${GITHUB_REF:11})" >> $GITHUB_ENV
     - name: Build and push to Docker Hub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: iublibtech/archives_online
         username: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore