### PR TITLE
Change the Universal Viewer to be embedded from a configurable source

### DIFF
--- a/app/renderers/universal_viewer.rb
+++ b/app/renderers/universal_viewer.rb
@@ -11,4 +11,12 @@ class UniversalViewer
   def manifest_url
     @document.digital_objects.first.href
   end
+
+  def uv_host
+    ENV['UV_HOST']
+  end
+
+  def uv_config_host
+    ENV['UV_CONFIG_HOST']
+  end
 end

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -1,7 +1,7 @@
 <% parents = Arclight::Parents.from_solr_document(document).as_parents %>
 <div class='row'>
   <div class='col-md-12'>
-    <% if document.digital_objects.present? %>
+    <% if document.digital_objects.present? && document.digital_objects.first.href.include?('iiif')%>
       <%= content_tag :p, class: "media breadcrumb-item breadcrumb-item-#{parents.length + 3}" do %>
         <span class="media-body al-online-content-icon" aria-hidden="true"><%= blacklight_icon :online %></span>
         <span class="col text-muted">

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -1,0 +1,70 @@
+<% parents = Arclight::Parents.from_solr_document(document).as_parents %>
+<div class='row'>
+  <div class='col-md-12'>
+    <% if document.digital_objects.present? %>
+      <%= content_tag :p, class: "media breadcrumb-item breadcrumb-item-#{parents.length + 3}" do %>
+        <span class="media-body al-online-content-icon" aria-hidden="true"><%= blacklight_icon :online %></span>
+        <span class="col text-muted">
+          <%= t('arclight.views.show.online_content_upper') %>
+        </span>
+        <%= render_document_partial(document, 'arclight_viewer') %>
+      <% end %>
+    <% end %>
+    <div class='row'>
+      <div class='col-md-12'>
+        <ul class='nav nav-tabs nav-fill' role='tablist' aria-label='<%= t('arclight.views.show.tablist_nav') %>'>
+          <li class='nav-item flex-fill'>
+            <a class='nav-link p-1 p-sm-2 active' data-toggle='tab' href='#context' role='tab'>
+              <%= t 'arclight.views.show.context' %>
+            </a>
+          </li>
+          <% if document.online_content? && document.children? %>
+            <li class='nav-item flex-fill'>
+              <a class='nav-link p-1 p-sm-2' data-toggle='tab' href='#online-content' role='tab' data-arclight-online-content-tab='true'>
+                <%= t 'arclight.views.show.online_content' %>
+                <span data-arclight-online-content-tab-count/>
+              </a>
+            </li>
+          <% end %>
+          <li class='nav-item flex-fill'>
+            <a class='nav-link p-1 p-sm-2' data-toggle='tab' href='#access' role='tab'>
+              <%= t 'arclight.views.show.access' %>
+            </a>
+          </li>
+        </ul>
+        <div class='tab-content'>
+          <div class='tab-pane active' id='context' role='tabpanel'>
+            <%= render 'component_context' %>
+          </div>
+          <% if document.online_content? && document.children? %>
+            <div class='tab-pane' id='online-content' role='tabpanel'>
+              <%= content_tag(
+                :div, '',
+                class: 'al-contents',
+                data: {
+                  arclight: {
+                    path: search_catalog_path,
+                    name: document.collection_name,
+                    access: 'online',
+                    view: 'online_contents',
+                    parent: document.reference,
+                    search_field: 'within_collection'
+                  }
+                }
+              ) %>
+            </div>
+          <% end %>
+          <div class='tab-pane' id='access' role='tabpanel'>
+            <h2 class="sr-only"><%= t 'arclight.views.show.access' %></h2>
+            <% unless blacklight_config.show.component_access_tab_items.nil? %>
+              <% items = blacklight_config.show.component_access_tab_items.select { |i|  fields_have_content?(@document, i) }  %>
+              <% items.each_with_index do |item, index| %>
+                <%= render partial: 'access_contents', locals: { document: @document, field_accessor: item, card_index: index} %>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/viewers/_universal_viewer.html.erb
+++ b/app/views/viewers/_universal_viewer.html.erb
@@ -1,22 +1,12 @@
-<div
-  id="uv"
-  class="uv" 
-  data-locale="en-GB:English (GB),cy-GB:Cymraeg" 
-  data-config="/uv_config.json" 
-  data-uri=<%= viewer.manifest_url %>
-  data-collectionindex="0" 
-  data-manifestindex="0" 
-  data-sequenceindex="0" 
-  data-canvasindex="0" 
-  data-xywh="-2204,-248,7873,4957" 
-  data-rotation="0" 
-  style="width:560px; height:420px; background-color: #000">
+
+<div>
+
+<iframe
+  src="<%= viewer.uv_host %>/uv/uv.html#?manifest=<%= viewer.manifest_url %>&config=<%= viewer.uv_config_host %>/uv/uv_config.json&m=0&cv=0"
+  width="1024" height="640" allowfullscreen frameborder="0">
+</iframe>
+
 </div>
-<script   
-  type="text/javascript" 
-  id="embedUV" 
-  src="https://pages.dlib.indiana.edu/bower_includes/universalviewer/dist/uv-2.0.1/lib/embed.js">
-</script>
 
 <script>
   (function() {


### PR DESCRIPTION
This changes the way that the Universal Viewer is initialized into a view.  Instead of a local installation, it pulls a remote viewer from a content provider into an inline frame element.

The source of the viewer is configurable in the runtime environment as:
```
UV_HOST
UV_CONFIG_HOST
```

If those values are absent, then the path to the viewer (and the UV configuration) will be a URL relative to the running application.  In that case it would expect a local installation.

Also, there is a temporary measure put in place to suppress the initialization of the viewer if the link that it gets from an EAD DAO does not match a known pattern.  This is a pretty opinionated piece of code; it is literally looking for our institutional PURL patterns that represent a IIIF manifest.  This is to provide flexibility during final legacy migration and can be taken back out when not needed.