### PR TITLE
Ar 196 remediation

### DIFF
--- a/app/assets/javascripts/context_navigation.js.erb
+++ b/app/assets/javascripts/context_navigation.js.erb
@@ -63,19 +63,19 @@ class ExpandButton {
   constructor(data) {
     var collapseIcon = `<img alt='collapse' src='<%= image_path('blacklight/collapse.svg') %>'>`;
     var expandIcon = `<img alt='expand' src='<%= image_path('blacklight/expand.svg') %>'>`;
-    
+
     // Find Siblings count
     var siblingCount =   `&nbsp;<span class='al-count'>999</span>&nbsp;`;
 
     this.collapseText =  collapseIcon + `Hide`+ siblingCount  + data.collapse;
     this.expandText =  expandIcon + `Show` + siblingCount + data.expand;
 
-    
+
     this.$el = $(`<button class="btn btn-link btn-sm">${this.expandText}</button>`);
     this.handleClick = this.handleClick.bind(this);
     this.$el.click(this.handleClick);
   }
-  
+
 }
 
 /**
@@ -187,11 +187,12 @@ class ContextNavigation {
     const $span = $('<span></span>');
     $span.addClass('divider');
     $span.attr('text-position', 'left');
+    $span.attr('role', 'listitem');
     $ul.append($span);
 
     const button = new ExpandButton(this.data);
     $span.append(button.$el);
-  
+
     return $ul;
   }
 
@@ -268,7 +269,7 @@ class ContextNavigation {
 
       prevParentList.append(renderedBeforeDocs);
 
-      
+
     } else {
       renderedBeforeDocs = beforeDocs.map(newDoc => newDoc.render()).join('');
     }
@@ -276,7 +277,7 @@ class ContextNavigation {
     // Silly but works for now
     this.ul.append(prevParentList || renderedBeforeDocs);
 
-  
+
     let itemDoc = newDocs.slice(newDocIndex, newDocIndex + 1);
     let renderedItemDoc = itemDoc.map(doc => doc.render()).join('');
 
@@ -370,7 +371,7 @@ class ContextNavigation {
     var srOnly = $('h2[data-sr-enable-me]');
     toEnable.removeClass('disabled');
     toEnable.text(srOnly.data('hasContents'));
-    srOnly.text(srOnly.data('hasContents'));  
+    srOnly.text(srOnly.data('hasContents'));
   }
 
   showSiblingCount(){
@@ -409,5 +410,5 @@ Blacklight.onLoad(function () {
       );
     contextNavigation.getData();
   });
- 
+
 });

--- a/app/assets/stylesheets/iu-branding.scss
+++ b/app/assets/stylesheets/iu-branding.scss
@@ -177,3 +177,14 @@ li.al-collection-context .al-online-content-icon svg,
 .toggle-delete:hover {
   text-decoration: none;
 }
+
+// Increase contrast ratios for accessibility
+.text-muted {
+  color: #34373a !important;
+}
+
+.facet-values {
+  .remove {
+    color: #0e0e0e !important;
+  }
+}

--- a/app/assets/stylesheets/iu-branding.scss
+++ b/app/assets/stylesheets/iu-branding.scss
@@ -185,6 +185,6 @@ li.al-collection-context .al-online-content-icon svg,
 
 .facet-values {
   .remove {
-    color: #0e0e0e !important;
+    color: #34373a !important;
   }
 }

--- a/app/views/catalog/_index_collection_context_default.html.erb
+++ b/app/views/catalog/_index_collection_context_default.html.erb
@@ -11,7 +11,7 @@
             <%= link_to(
           "##{document.id}-collapsible-hierarchy",
           class: "al-toggle-view-children #{!show_expanded?(document) ? 'collapsed' : ''}",
-          'aria-label': "Toggle children",
+          'aria-label': "Children of #{document.level} #{document.normalized_title} #{document.number_of_children}",
             data: {
               toggle: 'collapse'
             }

--- a/app/views/catalog/_show_collection.html.erb
+++ b/app/views/catalog/_show_collection.html.erb
@@ -1,0 +1,66 @@
+<% parents = Arclight::Parents.from_solr_document(document).as_parents %>
+<div class='row'>
+  <div class='col-md-12'>
+    <% if document.digital_objects.present? %>
+      <%= content_tag :p, class: "media breadcrumb-item breadcrumb-item-#{parents.length + 3}" do %>
+        <span class="media-body al-online-content-icon" aria-hidden="true"><%= blacklight_icon :online %></span>
+        <span class="col text-muted">
+          <%= t('arclight.views.show.online_content_upper') %>
+        </span>
+        <%= render_document_partial(document, 'arclight_viewer') %>
+      <% end %>
+    <% end %>    
+    <div class='row'>
+      <div class='col-lg-12'>
+        <ul class='nav nav-tabs nav-fill' role='tablist' aria-label='<%= t('arclight.views.show.tablist_nav') %>'>
+          <li class='nav-item flex-fill'>
+            <a class='nav-link p-1 p-sm-2 active' data-toggle='tab' href='#context' role='tab'>
+              <%= t 'arclight.views.show.overview' %>
+            </a>
+          </li>
+          <li class='nav-item flex-fill'>
+            <a class='nav-link p-1 p-sm-2 disabled' data-toggle='tab' href='#contents' role='tab' data-hierarchy-enable-me='true'>
+              <%= t 'arclight.views.show.no_contents' %>
+            </a>
+          </li>
+          <% if document.online_content? %>
+            <li class='nav-item flex-fill'>
+              <a class='nav-link p-1 p-sm-2' data-toggle='tab' href='#online-content' role='tab' data-arclight-online-content-tab='true'>
+                <%= t 'arclight.views.show.online_content' %>
+              </a>
+            </li>
+          <% end %>
+          <li class='nav-item flex-fill'>
+            <a class='nav-link p-1 p-sm-2' data-toggle='tab' href='#access' role='tab'>
+              <%= t 'arclight.views.show.access' %>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class='tab-content'>
+      <div class='tab-pane active' id='context' role='tabpanel'>
+        <%= render 'collection_context' %>
+      </div>
+      <div class='tab-pane' id='contents' role='tabpanel'>
+        <%= render 'collection_contents' %>
+      </div>
+      <% if document.online_content? %>
+        <div class='tab-pane' id='online-content' role='tabpanel'>
+          <%= render partial: 'collection_online_contents', locals: { document: document }  %>
+        </div>
+      <% end %>
+      <div class='tab-pane' id='access' role='tabpanel'>
+        <h2 class="sr-only"><%= t 'arclight.views.show.access' %></h2>
+        <% unless blacklight_config.show.context_access_tab_items.nil? %>
+          <% items = blacklight_config.show.context_access_tab_items.select { |i|  fields_have_content?(@document, i) }  %>
+          <% items.each_with_index do |item, index| %>
+            <%= render partial: 'access_contents', locals: { document: @document, field_accessor: item, card_index: index} %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/app/views/catalog/_show_collection.html.erb
+++ b/app/views/catalog/_show_collection.html.erb
@@ -9,29 +9,29 @@
         </span>
         <%= render_document_partial(document, 'arclight_viewer') %>
       <% end %>
-    <% end %>    
+    <% end %>
     <div class='row'>
-      <div class='col-lg-12'>
-        <ul class='nav nav-tabs nav-fill' role='tablist' aria-label='<%= t('arclight.views.show.tablist_nav') %>'>
+      <div class='col-lg-12' role='tablist' aria-owns='context-tab content-tab online-content-tab access-tab'>
+        <ul class='nav nav-tabs nav-fill' aria-label='<%= t('arclight.views.show.tablist_nav') %>'>
           <li class='nav-item flex-fill'>
-            <a class='nav-link p-1 p-sm-2 active' data-toggle='tab' href='#context' role='tab'>
+            <a class='nav-link p-1 p-sm-2 active' id='context-tab' data-toggle='tab' href='#context' role='tab'>
               <%= t 'arclight.views.show.overview' %>
             </a>
           </li>
           <li class='nav-item flex-fill'>
-            <a class='nav-link p-1 p-sm-2 disabled' data-toggle='tab' href='#contents' role='tab' data-hierarchy-enable-me='true'>
+            <a class='nav-link p-1 p-sm-2 disabled' id='content-tab' data-toggle='tab' href='#contents' role='tab' data-hierarchy-enable-me='true'>
               <%= t 'arclight.views.show.no_contents' %>
             </a>
           </li>
           <% if document.online_content? %>
             <li class='nav-item flex-fill'>
-              <a class='nav-link p-1 p-sm-2' data-toggle='tab' href='#online-content' role='tab' data-arclight-online-content-tab='true'>
+              <a class='nav-link p-1 p-sm-2' id='online-content-tab' data-toggle='tab' href='#online-content' role='tab' data-arclight-online-content-tab='true'>
                 <%= t 'arclight.views.show.online_content' %>
               </a>
             </li>
           <% end %>
           <li class='nav-item flex-fill'>
-            <a class='nav-link p-1 p-sm-2' data-toggle='tab' href='#access' role='tab'>
+            <a class='nav-link p-1 p-sm-2' id='access-tab' data-toggle='tab' href='#access' role='tab'>
               <%= t 'arclight.views.show.access' %>
             </a>
           </li>

--- a/app/views/viewers/_universal_viewer.html.erb
+++ b/app/views/viewers/_universal_viewer.html.erb
@@ -3,7 +3,7 @@
 
 <iframe
   src="<%= viewer.uv_host %>/uv/uv.html#?manifest=<%= viewer.manifest_url %>&config=<%= viewer.uv_config_host %>/uv/uv_config.json&m=0&cv=0"
-  width="1024" height="640" allowfullscreen frameborder="0">
+  title="Digital content viewer" width="1024" height="640" allowfullscreen frameborder="0">
 </iframe>
 
 </div>


### PR DESCRIPTION
This PR addresses more accessibility issues reported by Siteimprove, as detailed in [AR-196](https://iu-uits.atlassian.net/browse/AR-196).

#### Issue specific notes:

##### [AR-203](https://iu-uits.atlassian.net/browse/AR-203) Role not in required context

- Role issues were fixed in #305 but the same problem occurred in the collection level navigation tabs, so same fix as before.
- Caused by assigning ARIA roles to elements that already have implicit roles, making them semantically incompatible with implicit roles of parent or child elements.
- Affected Context/Content/Digital Content/Access tabs
- Solution also fixes one occurrence of [AR-201](https://iu-uits.atlassian.net/browse/AR-201)

##### [AR-199](https://iu-uits.atlassian.net/browse/AR-199) / [AR-204](https://iu-uits.atlassian.net/browse/AR-204) Visible label and accessible name do not match
- When the Series/Subseries levels contain children, a link is generated with an accessible label.  However, it was generically assigned "toggle children" and therefore didn't match the full displayed text.
- Fixed by using the same data bits to generate the label as the link text, prepended with "Children for" (ARIA allows the label to contain additional supporting text as long as it also contains the full display text.)

##### [AR-200](https://iu-uits.atlassian.net/browse/AR-200) Color contrast does not meet minimum requirement
- Most of these are caused by the use of `.muted-text`, which produces a ratio just below the minimum
- Added override for `.muted-text` to a darker grayscale value

##### [AR-201](https://iu-uits.atlassian.net/browse/AR-201) Container element is empty
- Another occurrence of this issue was being caused by the context navigation control to "Show x number of items above"
-- There is a formatting `span` element as a direct child to a `ul` element, which is an invalid implicit role relationship
-- Fixed by adding the `listitem` role to the `span` element

##### [AR-120](https://iu-uits.atlassian.net/browse/AR-120) All non-text elements must be screen readable and/or offer alternative text
- The `iframe` that instantiates the Universal viewer did not have a title