### PR TITLE
AR-196 Accessibility remediation

### DIFF
--- a/app/templates/template.xslt
+++ b/app/templates/template.xslt
@@ -8,7 +8,7 @@
 	<xsl:output method="html" encoding="UTF-8" doctype-public="-//W3C//DTD HTML 4.0 Transitional//EN"/>
 	<!-- Creates the body of the finding aid.-->
 	<xsl:template match="/ead">
-		<html>
+		<html lang="en">
 			<!-- ****************************************************************** -->
 			<!-- Outputs header information for the HTML document 			-->
 			<!-- ****************************************************************** -->


### PR DESCRIPTION
This PR addresses more accessibility issues reported by Siteimprove, as detailed in [AR-196](https://iu-uits.atlassian.net/browse/AR-196).

#### Issue specific notes:

##### [AR-198](https://iu-uits.atlassian.net/browse/AR-198) Page language has not been identified
- During indexing, a XSL transformation creates HTML versions of each EAD.  The opening `html` tag in the XSLT was missing the language attribute.