### PR TITLE
Ensure Solr documents are removed when finding aid deleted

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,9 @@ jobs:
     - run:
         name: Install dependencies
         command: |
-          gem update --system
-          gem update bundler
+          # We can't do these global gem updates because our support Ruby is falling too far behind...
+          # gem update --system
+          # gem update bundler
           bundle config path $CIRCLE_WORKING_DIRECTORY/vendor/bundle
           bundle install
           bundle pristine webdrivers

--- a/lib/tasks/delete_ead.rake
+++ b/lib/tasks/delete_ead.rake
@@ -6,7 +6,7 @@ namespace :ngao do
     raise 'Please specify your EAD document, ex. ead.xml' unless ENV['FILE']
 
     filename = ENV['FILE']
-    solr_id = File.basename(filename)
+    solr_id = File.basename(filename, '.xml')
     raise "Unexpected file type: #{File.extname(filename)}" unless  File.extname(filename) =~/.xml/
 
     puts "NGAO-Arclight deleting #{ENV['FILE']}...\n"
@@ -24,7 +24,10 @@ namespace :ngao do
     solr_url = solr_url.chomp('/')
 
     solr_elapsed_time = Benchmark.realtime do
+      puts "Deleting document with ID #{solr_id}"
       system(%Q{curl -s -X POST "#{solr_url}/update?commit=true" -H "Content-Type: text/xml" --data-binary "<delete><id>#{solr_id}</id></delete>"}, exception: true)
+      # Ensure related component level documents are also deleted...
+      system(%Q{curl -s -X POST "#{solr_url}/update?commit=true" -H "Content-Type: text/xml" --data-binary "<delete><ead_ssi>#{solr_id}</ead_ssi></delete>"}, exception: true)
     end
 
     puts "NGAO-Arclight deleted #{filename} from solr index (in #{solr_elapsed_time.round(3)} secs).\n"


### PR DESCRIPTION
While trying to figure out how to make sure all documents related to a finding aid are being deleted (i.e. all of the component levels and the main level) it was discovered that deleting wasn't working at all.  This was due to the failure to get the base ID off of the provided filename.  It's not clear if this never worked, or something changed with the `File` method being used over time.

It also ensures all related documents will be deleted by explicitly adding another delete query targeting the `ead_ssi` field.

Also, a new CI error had started occurring because a couple of `gem` update commands were causing dependencies to be updated past compatibility with the 2.7.* ruby.  So this disables those for now.