### PR TITLE
Accessibility fix, AR-203 when catalog controller has no params

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -11,8 +11,8 @@
             <%= link_to t('arclight.masthead_heading'), root_path, class: 'h1' %>
           </div>
 
-          <div class="col-md-4 nav-links d-flex justify-content-end" >
-            <ul class="navbar-nav" aria-label="browse" role="navigation">
+          <div class="col-md-4 nav-links d-flex justify-content-end" role="navigation">
+            <ul class="navbar-nav" aria-label="browse">
               <%= render 'shared/main_menu_links' %>
             </ul>
           </div>


### PR DESCRIPTION
Fixes another instance of roles being improperly assigned to elements and changing their implied role in context.  The "Repositories/Collection" navigation bar on all pages was fixed in first rounds of remediation, but this one got missed.  It only happens when the catalog controller is accessed without any search parameters.  No user can even reach this result via normal navigation, but somehow the Siteimprove crawler found it and flagged it.

