### PR TITLE
Accessibility: Increasing contrast ratio on the interim label of the contents tab

### DIFF
--- a/app/assets/stylesheets/iu-branding.scss
+++ b/app/assets/stylesheets/iu-branding.scss
@@ -131,6 +131,7 @@ li.al-collection-context .al-online-content-icon svg,
 }
 // tabs on the collect/item pages
 .nav.nav-tabs .nav-item .nav-link:not(.active) {
+  color: #484e53;
   background-color: $iu-cream;
 }
 .nav-pills .nav-link.active,


### PR DESCRIPTION
The "Contents" tab can be conditionally disabled visually if it finds no components to parse.  However, this happens for all collections as the page loads, as it is still calculating the components list. In that split second, Siteimprove is able to see that tab and flags it with a contrast ratio violation.  This overrides the default color for the disabled class to a darker color, but only for a navigation link.