### PR TITLE
Refining Google Analytics in base layout to suppress for dev environments

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -14,7 +14,7 @@
     <%= stylesheet_link_tag "application", media: "all" %>
     <%= javascript_include_tag "application" %>
 
-    <% if ENV['SITE_HOST']&.include?('.edu') %>
+    <% unless ENV['SITE_HOST'] =~ /localhost|devel|stage|test|preview/ %>
       <!-- Google tag (gtag.js) -->
       <script async src="https://www.googletagmanager.com/gtag/js?id=G-J2B2XVXX8M"></script>
       <script>


### PR DESCRIPTION
Suppressing the Google Analytics script element if the running site is a development environment (i.e. localhost, test, devel, stage etc.)