### PR TITLE
Correcting link to legacy Archives Online

### DIFF
--- a/app/views/arclight/repositories/index.html.erb
+++ b/app/views/arclight/repositories/index.html.erb
@@ -7,7 +7,7 @@
 
   <%# ADD CUSTOM CONTENT HERE FOR NGAO REPOSITORY PAGE CONTENT %>
   <h2>Welcome to Archives Online</h2>
-  <p>Archives Online is a portal for accessing descriptions of archival and special collections held by libraries, archives and other cultural heritage units at Indiana University or affiliated with Indiana University. The collection descriptions (finding aids) are for non-book and original research materials such as correspondence and photographs. This new Archives Online site is currently under development and does not yet contain links to digitized materials from collections or all collections from IUPUI. To view digitized archival materials, visit <a href="http://www.dlib.indiana.edu/collections/findingaids">Legacy Archives Online</a>. To view additional IUPUI collections, visit <a href="https://www.ulib.iupui.edu/special">Ruth Lilly Special Collections &amp; Archives</a>.</p>
+  <p>Archives Online is a portal for accessing descriptions of archival and special collections held by libraries, archives and other cultural heritage units at Indiana University or affiliated with Indiana University. The collection descriptions (finding aids) are for non-book and original research materials such as correspondence and photographs. This new Archives Online site is currently under development and does not yet contain links to digitized materials from collections or all collections from IUPUI. To view digitized archival materials, visit <a href="https://webapp1.dlib.indiana.edu/findingaids">Legacy Archives Online</a>. To view additional IUPUI collections, visit <a href="https://www.ulib.iupui.edu/special">Ruth Lilly Special Collections &amp; Archives</a>.</p>
 
   <div class="col-md-12 light-gray">
     <%# ADD CAMPUS CARDS %>
@@ -16,7 +16,7 @@
         <%= render partial: 'campus_card', locals: {campus: campus.first} %>
       <% end %>
     </div>
-  
+
     <%# ADDED CAMPUS LEVEL FOR DISPLAY %>
     <% @campuses.each do |campus, repositories| %>
       <h2 id="<%= campus %>" class="repository-header"><%= convert_campus_id(campus) %></h2>


### PR DESCRIPTION
An old style link was inconsistently giving a 404 on redirect to legacy Archives Online. Changed to be the direct link on the app server.